### PR TITLE
Release 1.3.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,17 @@
-; This file is for unifying the coding style for different editors and IDEs.
-; More information at http://editorconfig.org
-
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
-end_of_line = lf
+charset = utf-8
+end_of_line = LF
 insert_final_newline = true
 trim_trailing_whitespace = true
-charset = utf-8
 
-[*.yml]
-indent_size = 2
+[*.{php}]
+indent_style = space
+indent_size = 4
 
-[*.neon]
-indent_size = 2
+[*.md]
+max_line_length = 80
 
-[*.json]
-indent_size = 2
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * eol=lf
 * text=auto
 *.php diff=php
+*.jpg binary
 
 /.github                export-ignore
 /doc/                   export-ignore
@@ -15,3 +16,8 @@
 /phpcs.xml              export-ignore
 /phpstan.neon           export-ignore
 /phpunit.xml            export-ignore
+
+/src/Generated          linguist-generated=true
+/doc/samples/Generated  linguist-generated=true
+/tests/**/Generated     linguist-generated=true
+/tests/**/*.json        linguist-generated=true

--- a/bin/generate-transfer
+++ b/bin/generate-transfer
@@ -13,7 +13,7 @@ function includeAutoload(string $path): bool
 
 if (
     !includeAutoload(__DIR__ . '/../../autoload.php')
-    && !includeAutoload(__DIR__ . '/vendor/autoload.php')
+    && !includeAutoload(__DIR__ . '/../vendor/autoload.php')
 ) {
     fwrite(STDERR, 'Failed include autoload file.' . PHP_EOL);
     exit(1);

--- a/bin/generate-transfer
+++ b/bin/generate-transfer
@@ -6,18 +6,7 @@ declare(strict_types=1);
 use Picamator\TransferObject\Command\TransferGeneratorCommand;
 use Symfony\Component\Console\Application;
 
-function includeAutoload(string $path): bool
-{
-    return file_exists($path) && include $path;
-}
-
-if (
-    !includeAutoload(__DIR__ . '/../../autoload.php')
-    && !includeAutoload(__DIR__ . '/../vendor/autoload.php')
-) {
-    fwrite(STDERR, 'Failed include autoload file.' . PHP_EOL);
-    exit(1);
-}
+include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
 $application = new Application(name:'TransferObject', version:'current');
 $command = new TransferGeneratorCommand();

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "picamator/transfer-object",
-  "description": "Transfer Object based on property Hooks, includes generator by yml definition.",
-  "keywords": ["dev", "code generator", "transfer object"],
+  "description": "Transfer Object Generator based on property hooks and FixedArray.",
+  "keywords": ["generator", "code generator", "transfer object", "data transfer object", "dto", "dev"],
   "license": "MIT",
   "authors": [
     {
@@ -9,7 +9,8 @@
     }
   ],
   "support": {
-    "issues": "https://github.com/picamator/transfer-object/issues"
+    "issues": "https://github.com/picamator/transfer-object/issues",
+    "wiki": "https://github.com/picamator/transfer-object/wiki"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   "autoload": {
     "psr-4": {
       "Picamator\\TransferObject\\": "src/"
-    },
-    "exclude-from-classmap": ["/tests/", "/doc/"]
+    }
   },
   "autoload-dev": {
     "psr-4": {
@@ -45,6 +44,7 @@
   "config": {
     "sort-packages": true
   },
+  "prefer-stable": true,
   "scripts": {
     "phpunit": "./vendor/bin/phpunit",
     "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,12 @@
   },
   "require": {
     "php": ">=8.4",
-    "symfony/finder": "^7.0",
-    "symfony/yaml": "^7.0",
-    "symfony/filesystem": "^7.0",
+    "composer-runtime-api": "^2.2",
+    "psr/container": "^2.0",
     "symfony/console": "^7.0",
-    "psr/container": "^2.0"
+    "symfony/filesystem": "^7.0",
+    "symfony/finder": "^7.0",
+    "symfony/yaml": "^7.0"
   },
   "require-dev": {
     "captainhook/captainhook": "^5.24",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "squizlabs/php_codesniffer": "^3.11"
   },
   "bin": [
-    "generate-transfer"
+    "bin/generate-transfer"
   ],
   "config": {
     "sort-packages": true
@@ -48,7 +48,7 @@
   "scripts": {
     "phpunit": "./vendor/bin/phpunit",
     "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon",
-    "generate-transfer": "php ./generate-transfer",
+    "generate-transfer": "php ./bin/generate-transfer",
     "captainhook": "./vendor/bin/captainhook",
     "phpcs": "./vendor/bin/phpcs",
     "phpcbf": "./vendor/bin/phpcbf"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5a8e73f23b97e74ddeec169c8c48a97",
+    "content-hash": "09bdcf302518397886f53e7bd54660f3",
     "packages": [
         {
             "name": "psr/container",
@@ -3118,7 +3118,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4"
+        "php": ">=8.4",
+        "composer-runtime-api": "^2.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e60390222099201c80ca8039dc2a264a",
+    "content-hash": "b5a8e73f23b97e74ddeec169c8c48a97",
     "packages": [
         {
             "name": "psr/container",
@@ -3115,7 +3115,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,7 @@
     <file>src</file>
     <file>tests</file>
     <file>doc</file>
+    <file>bin</file>
 
     <exclude-pattern>*/tests/*/data/*</exclude-pattern>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ parameters:
     - src
     - tests
     - doc
-    - generate-transfer
+    - bin
   excludePaths:
     - tests/*/data/*
   ignoreErrors:


### PR DESCRIPTION
Implemented
=========

1. Moved command `generate-transfer` from project root to `bin` directory
2. Actualised `composer.json`: added keywords, wiki, stable version etc.
3. Added `linguist-generated` option to the `.gitattributes`
4. Used composer global variable to resolve console command autoload path