### PR TITLE
Release 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,80 +1,81 @@
 {
-  "name": "picamator/transfer-object",
-  "description": "A modern Symfony-compatible Transfer Object Generator with property hooks, FixedArray, and asymmetric visibilities.",
-  "keywords": [
-      "generator",
-      "code generator",
-      "data transfer object",
-      "dto",
-      "transfer object",
-      "symfony",
-      "automation"
-  ],
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Sergii Pryz"
-    }, {
-      "name": "Community",
-      "homepage": "https://github.com/picamator/transfer-object/graphs/contributors"
+    "name": "picamator/transfer-object",
+    "description": "A modern Symfony-compatible Transfer Object Generator with property hooks, FixedArray, and asymmetric visibilities.",
+    "keywords": [
+        "generator",
+        "code generator",
+        "data transfer object",
+        "dto",
+        "transfer object",
+        "symfony",
+        "automation"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sergii Pryz"
+        },
+        {
+            "name": "Community",
+            "homepage": "https://github.com/picamator/transfer-object/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/picamator/transfer-object/issues",
+        "wiki": "https://github.com/picamator/transfer-object/wiki",
+        "security": "https://github.com/picamator/transfer-object/security/policy"
+    },
+    "autoload": {
+        "psr-4": {
+            "Picamator\\TransferObject\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Picamator\\Tests\\Unit\\TransferObject\\": "tests/unit/",
+            "Picamator\\Tests\\Integration\\TransferObject\\": "tests/integration/",
+            "Picamator\\Doc\\Samples\\TransferObject\\": "doc/samples"
+        }
+    },
+    "require": {
+        "php": ">=8.4",
+        "composer-runtime-api": "^2.2",
+        "psr/container": "^2.0",
+        "symfony/console": "^7.0",
+        "symfony/filesystem": "^7.0",
+        "symfony/finder": "^7.0",
+        "symfony/yaml": "^7.0"
+    },
+    "require-dev": {
+        "captainhook/captainhook": "^5.24",
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^12.0",
+        "squizlabs/php_codesniffer": "^3.11"
+    },
+    "bin": [
+        "bin/transfer-generate",
+        "bin/definition-generate"
+    ],
+    "config": {
+        "sort-packages": true
+    },
+    "prefer-stable": true,
+    "scripts": {
+        "phpunit": "./vendor/bin/phpunit --no-progress",
+        "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon --no-progress --memory-limit=512M",
+        "transfer-generate": "php ./bin/transfer-generate",
+        "definition-generate": "php ./bin/definition-generate",
+        "captainhook": "./vendor/bin/captainhook",
+        "phpcs": "./vendor/bin/phpcs",
+        "phpcbf": "./vendor/bin/phpcbf"
+    },
+    "scripts-descriptions": {
+        "phpunit": "Run unit and integration tests.",
+        "phpstan": "Perform static code analysis using PHPStan.",
+        "transfer-generate": "Generate Transfer Objects from YML definition templates.",
+        "definition-generate": "Create Transfer Object definition files based on JSON blueprints.",
+        "captainhook": "Manage and execute Git hooks.",
+        "phpcs": "Analyze code style using PHP CodeSniffer.",
+        "phpcbf": "Automatically fix coding style issues with PHP Code Beautifier and Fixer."
     }
-  ],
-  "support": {
-    "issues": "https://github.com/picamator/transfer-object/issues",
-    "wiki": "https://github.com/picamator/transfer-object/wiki",
-    "security": "https://github.com/picamator/transfer-object/security/policy"
-  },
-  "autoload": {
-    "psr-4": {
-      "Picamator\\TransferObject\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Picamator\\Tests\\Unit\\TransferObject\\": "tests/unit/",
-      "Picamator\\Tests\\Integration\\TransferObject\\": "tests/integration/",
-      "Picamator\\Doc\\Samples\\TransferObject\\": "doc/samples"
-    }
-  },
-  "require": {
-    "php": ">=8.4",
-    "composer-runtime-api": "^2.2",
-    "psr/container": "^2.0",
-    "symfony/console": "^7.0",
-    "symfony/filesystem": "^7.0",
-    "symfony/finder": "^7.0",
-    "symfony/yaml": "^7.0"
-  },
-  "require-dev": {
-    "captainhook/captainhook": "^5.24",
-    "phpstan/phpstan": "^2.0",
-    "phpunit/phpunit": "^12.0",
-    "squizlabs/php_codesniffer": "^3.11"
-  },
-  "bin": [
-    "bin/transfer-generate",
-    "bin/definition-generate"
-  ],
-  "config": {
-    "sort-packages": true
-  },
-  "prefer-stable": true,
-  "scripts": {
-    "phpunit": "./vendor/bin/phpunit --no-progress",
-    "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon --no-progress --memory-limit=512M",
-    "transfer-generate": "php ./bin/transfer-generate",
-    "definition-generate": "php ./bin/definition-generate",
-    "captainhook": "./vendor/bin/captainhook",
-    "phpcs": "./vendor/bin/phpcs",
-    "phpcbf": "./vendor/bin/phpcbf"
-  },
-  "scripts-descriptions": {
-    "phpunit": "Run PHPUnit tests.",
-    "phpstan": "Run PHPStan - PHP Static Analysis Tool.",
-    "transfer-generate": "Run Transfer Object Generator.",
-    "definition-generate": "Run Definition Generator.",
-    "captainhook": "Run CaptanHooks.",
-    "phpcs": "Run PHP CodeSniffer.",
-    "phpcbf": "Run PHP Code Beautifier and Fixer."
-  }
 }

--- a/config/definition/transfer-generator.transfer.yml
+++ b/config/definition/transfer-generator.transfer.yml
@@ -23,6 +23,9 @@ ConfigContent:
   definitionPath:
     type: string
     required:
+  relativeDefinitionPath:
+    type: string
+    required:
 
 Definition:
   fileName:

--- a/src/Command/DefinitionGeneratorCommand.php
+++ b/src/Command/DefinitionGeneratorCommand.php
@@ -17,16 +17,16 @@ use Throwable;
 class DefinitionGeneratorCommand extends Command
 {
     private const string NAME = 'picamator:definition:generate';
-    private const string DESCRIPTION = 'Generates Transfer Object definition files.';
+    private const string DESCRIPTION = 'Generates Transfer Object Definition Files based on JSON file as a blueprint.';
     private const string HELP = <<<'HELP'
-Based on JSON file, generates Transfer Object definition files.
+Answer on interactive questions to set Definition File Path, Transfer Object Class Name, and JSON File Path."
 HELP;
 
     private const string QUESTION_DEFINITION_PATH = 'Definition directory path: ';
     private const string QUESTION_CLASS_NAME = 'Transfer Object class name: ';
     private const string QUESTION_JSON_PATH = 'JSON file path: ';
 
-    private const string START_SECTION_NAME = 'Definition Generation';
+    private const string START_SECTION_NAME = 'Definition Files Generation';
 
     private const string SUCCESS_MESSAGE_TEMPLATE = 'Definition files %d were generated successfully.';
 

--- a/src/Command/DefinitionGeneratorCommand.php
+++ b/src/Command/DefinitionGeneratorCommand.php
@@ -17,18 +17,25 @@ use Throwable;
 class DefinitionGeneratorCommand extends Command
 {
     private const string NAME = 'picamator:definition:generate';
-    private const string DESCRIPTION = 'Generates Transfer Object Definition Files based on JSON file as a blueprint.';
+    private const string DESCRIPTION = 'Generate Transfer Object definition files from a JSON blueprint.';
     private const string HELP = <<<'HELP'
-Answer on interactive questions to set Definition File Path, Transfer Object Class Name, and JSON File Path."
+This command allows you to generate Transfer Object definition files based on a JSON file as a blueprint.
+
+You will be prompted to provide the following details:
+  - The directory path where the definition files should be saved.
+  - The class name for the Transfer Object.
+  - The path to the JSON file that serves as a blueprint.
+
+Follow the interactive prompts to complete the process.
 HELP;
 
     private const string QUESTION_DEFINITION_PATH = 'Definition directory path: ';
     private const string QUESTION_CLASS_NAME = 'Transfer Object class name: ';
     private const string QUESTION_JSON_PATH = 'JSON file path: ';
 
-    private const string START_SECTION_NAME = 'Definition Files Generation';
+    private const string START_SECTION_NAME = 'Generating Transfer Object Definitions...';
 
-    private const string SUCCESS_MESSAGE_TEMPLATE = 'Definition files %d were generated successfully.';
+    private const string SUCCESS_MESSAGE_TEMPLATE = 'Successfully generated %d definition file(s)!';
 
     public function __construct(
         ?string $name = null,

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -16,25 +16,30 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class TransferGeneratorCommand extends Command
 {
     private const string NAME = 'picamator:transfer:generate';
-    private const string DESCRIPTION = 'Generates Transfer Objects based on definitions template.';
+    private const string DESCRIPTION = 'Generate Transfer Objects from definition templates.';
     private const string HELP = <<<'HELP'
-Configuration option includes path to Definition Files directory, Transfer Object namespace,
-and the path to generated objects.
+This command generates Transfer Objects based on YML definitions.
+The command requires a path to the configuration file in YML format.
+
+The configuration specifies:
+  - The directory containing the definition files.
+  - The namespace for the Transfer Objects.
+  - The output directory where the generated Transfer Objects will be saved.
 HELP;
 
     private const string OPTION_NAME_CONFIGURATION = 'configuration';
     private const string OPTION_SHORTCUT_CONFIGURATION = 'c';
-    private const string OPTION_DESCRIPTION_CONFIGURATION = 'Path to YML configuration.';
+    private const string OPTION_DESCRIPTION_CONFIGURATION = 'Path to the YML configuration file.';
 
-    private const string START_SECTION_NAME = 'Transfer Object Generation';
+    private const string START_SECTION_NAME = 'Generating Transfer Objects...';
 
     private const string ERROR_MISSED_OPTION_CONFIG_MESSAGE =
-        'Command option -c is not set. Please provide the path to the YML configuration.';
+        'The required -c option is missing. Please provide the path to the YML configuration file.';
 
-    private const string TRANSFER_OBJECT_MESSAGE_TEMPLATE = 'Transfer Object: "%s".';
-    private const string DEFINITION_MESSAGE_TEMPLATE = 'Definition file: "%s".';
+    private const string TRANSFER_OBJECT_MESSAGE_TEMPLATE = 'Processing Transfer Object: "%s".';
+    private const string DEFINITION_MESSAGE_TEMPLATE = 'Using definition file: "%s".';
 
-    private const string SUCCESS_MESSAGE = 'Transfer Objects were generated successfully.';
+    private const string SUCCESS_MESSAGE = 'All Transfer Objects were generated successfully!';
 
     public function __construct(
         ?string $name = null,

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -18,7 +18,7 @@ class TransferGeneratorCommand extends Command
     private const string NAME = 'picamator:transfer:generate';
     private const string DESCRIPTION = 'Generates Transfer Objects based on definitions template.';
     private const string HELP = <<<'HELP'
-Configuration option includes path to definition directory, transfer object namespace,
+Configuration option includes path to Definition Files directory, Transfer Object namespace,
 and the path to generated objects.
 HELP;
 

--- a/src/DefinitionGenerator/DefinitionGeneratorFacadeInterface.php
+++ b/src/DefinitionGenerator/DefinitionGeneratorFacadeInterface.php
@@ -17,8 +17,8 @@ interface DefinitionGeneratorFacadeInterface
      *
      * @api
      *
-     * @example ./doc/samples/try-definition-generator.php
-     * @example ./src/Command/DefinitionGeneratorCommand.php
+     * @example /doc/samples/try-definition-generator.php
+     * @example /src/Command/DefinitionGeneratorCommand.php
      *
      * @throws \Picamator\TransferObject\Shared\Exception\TransferExceptionInterface
      */
@@ -32,7 +32,7 @@ interface DefinitionGeneratorFacadeInterface
      *
      * @internal
      *
-     * @example ./src/Command/DefinitionGeneratorCommand.php
+     * @example /src/Command/DefinitionGeneratorCommand.php
      */
     public function createDefinitionGeneratorBuilder(): DefinitionGeneratorBuilderInterface;
 }

--- a/src/Generated/ConfigContentTransfer.php
+++ b/src/Generated/ConfigContentTransfer.php
@@ -17,10 +17,11 @@ use Picamator\TransferObject\Transfer\AbstractTransfer;
  */
 final class ConfigContentTransfer extends AbstractTransfer
 {
-    protected const int META_DATA_SIZE = 3;
+    protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
         self::DEFINITION_PATH => self::DEFINITION_PATH_DATA_NAME,
+        self::RELATIVE_DEFINITION_PATH => self::RELATIVE_DEFINITION_PATH_DATA_NAME,
         self::TRANSFER_NAMESPACE => self::TRANSFER_NAMESPACE_DATA_NAME,
         self::TRANSFER_PATH => self::TRANSFER_PATH_DATA_NAME,
     ];
@@ -35,10 +36,20 @@ final class ConfigContentTransfer extends AbstractTransfer
         set => $this->setData(self::DEFINITION_PATH_DATA_INDEX, $value);
     }
 
+    // relativeDefinitionPath
+    public const string RELATIVE_DEFINITION_PATH = 'relativeDefinitionPath';
+    protected const string RELATIVE_DEFINITION_PATH_DATA_NAME = 'RELATIVE_DEFINITION_PATH';
+    protected const int RELATIVE_DEFINITION_PATH_DATA_INDEX = 1;
+
+    public string $relativeDefinitionPath {
+        get => $this->getData(self::RELATIVE_DEFINITION_PATH_DATA_INDEX);
+        set => $this->setData(self::RELATIVE_DEFINITION_PATH_DATA_INDEX, $value);
+    }
+
     // transferNamespace
     public const string TRANSFER_NAMESPACE = 'transferNamespace';
     protected const string TRANSFER_NAMESPACE_DATA_NAME = 'TRANSFER_NAMESPACE';
-    protected const int TRANSFER_NAMESPACE_DATA_INDEX = 1;
+    protected const int TRANSFER_NAMESPACE_DATA_INDEX = 2;
 
     public string $transferNamespace {
         get => $this->getData(self::TRANSFER_NAMESPACE_DATA_INDEX);
@@ -48,7 +59,7 @@ final class ConfigContentTransfer extends AbstractTransfer
     // transferPath
     public const string TRANSFER_PATH = 'transferPath';
     protected const string TRANSFER_PATH_DATA_NAME = 'TRANSFER_PATH';
-    protected const int TRANSFER_PATH_DATA_INDEX = 2;
+    protected const int TRANSFER_PATH_DATA_INDEX = 3;
 
     public string $transferPath {
         get => $this->getData(self::TRANSFER_PATH_DATA_INDEX);

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -10,6 +10,9 @@ use ReflectionClassConstant;
 use SplFixedArray;
 use Traversable;
 
+/**
+ * @api
+ */
 abstract class AbstractTransfer implements TransferInterface
 {
     protected const int META_DATA_SIZE = 0;

--- a/src/Transfer/Attribute/ArrayObjectPropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/ArrayObjectPropertyTypeAttribute.php
@@ -8,6 +8,9 @@ use ArrayObject;
 use Attribute;
 use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
 
+/**
+ * @api
+ */
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 final readonly class ArrayObjectPropertyTypeAttribute implements PropertyTypeAttributeInterface
 {

--- a/src/Transfer/Attribute/ArrayPropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/ArrayPropertyTypeAttribute.php
@@ -7,6 +7,9 @@ namespace Picamator\TransferObject\Transfer\Attribute;
 use Attribute;
 use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
 
+/**
+ * @api
+ */
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 final readonly class ArrayPropertyTypeAttribute implements PropertyTypeAttributeInterface
 {

--- a/src/Transfer/Attribute/CollectionPropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/CollectionPropertyTypeAttribute.php
@@ -9,6 +9,9 @@ use Attribute;
 use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
 use Picamator\TransferObject\Transfer\TransferInterface;
 
+/**
+ * @api
+ */
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 final readonly class CollectionPropertyTypeAttribute implements PropertyTypeAttributeInterface
 {

--- a/src/Transfer/Attribute/EnumPropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/EnumPropertyTypeAttribute.php
@@ -8,6 +8,9 @@ use Attribute;
 use BackedEnum;
 use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
 
+/**
+ * @api
+ */
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 final readonly class EnumPropertyTypeAttribute implements PropertyTypeAttributeInterface
 {

--- a/src/Transfer/Attribute/PropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/PropertyTypeAttribute.php
@@ -8,6 +8,9 @@ use Attribute;
 use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
 use Picamator\TransferObject\Transfer\TransferInterface;
 
+/**
+ * @api
+ */
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 final readonly class PropertyTypeAttribute implements PropertyTypeAttributeInterface
 {

--- a/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
+++ b/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer\Attribute;
 
+/**
+ * @api
+ */
 interface PropertyTypeAttributeInterface
 {
     /**

--- a/src/Transfer/DummyTransferAdapterTrait.php
+++ b/src/Transfer/DummyTransferAdapterTrait.php
@@ -13,7 +13,9 @@ use Traversable;
  * - Simplifies integration with external transfer objects by removing the need to implement all interface methods.
  * - Intended for use as a placeholder in cases where full method functionality is not required.
  *
- * @example ./doc/samples/try-advanced-transfer-generator.php
+ * @api
+ *
+ * @example /doc/samples/try-advanced-transfer-generator.php
  */
 trait DummyTransferAdapterTrait
 {

--- a/src/Transfer/Exception/PropertyTypeTransferException.php
+++ b/src/Transfer/Exception/PropertyTypeTransferException.php
@@ -7,6 +7,9 @@ namespace Picamator\TransferObject\Transfer\Exception;
 use Exception;
 use Picamator\TransferObject\Shared\Exception\TransferExceptionInterface;
 
+/**
+ * @api
+ */
 class PropertyTypeTransferException extends Exception implements TransferExceptionInterface
 {
 }

--- a/src/TransferGenerator/Config/Config/Config.php
+++ b/src/TransferGenerator/Config/Config/Config.php
@@ -27,4 +27,9 @@ final readonly class Config implements ConfigInterface
     {
         return $this->configTransfer->definitionPath;
     }
+
+    public function getRelativeDefinitionPath(): string
+    {
+        return $this->configTransfer->relativeDefinitionPath;
+    }
 }

--- a/src/TransferGenerator/Config/Config/ConfigInterface.php
+++ b/src/TransferGenerator/Config/Config/ConfigInterface.php
@@ -20,4 +20,9 @@ interface ConfigInterface
      * @throws \Picamator\TransferObject\TransferGenerator\Config\Exception\ConfigNotFoundException
      */
     public function getDefinitionPath(): string;
+
+    /**
+     * @throws \Picamator\TransferObject\TransferGenerator\Config\Exception\ConfigNotFoundException
+     */
+    public function getRelativeDefinitionPath(): string;
 }

--- a/src/TransferGenerator/Config/Config/ConfigProxy.php
+++ b/src/TransferGenerator/Config/Config/ConfigProxy.php
@@ -25,6 +25,11 @@ final class ConfigProxy implements ConfigInterface
         return $this->getConfig()->getDefinitionPath();
     }
 
+    public function getRelativeDefinitionPath(): string
+    {
+        return $this->getConfig()->getRelativeDefinitionPath();
+    }
+
     public static function loadConfig(ConfigInterface $config): void
     {
         self::$config = $config;

--- a/src/TransferGenerator/Config/Enum/ConfigKeyEnum.php
+++ b/src/TransferGenerator/Config/Enum/ConfigKeyEnum.php
@@ -12,19 +12,6 @@ enum ConfigKeyEnum: string
     case TRANSFER_PATH = ConfigContentTransfer::TRANSFER_PATH;
     case DEFINITION_PATH = ConfigContentTransfer::DEFINITION_PATH;
 
-    private const array PATH_KEYS = [
-      self::TRANSFER_PATH,
-      self::DEFINITION_PATH,
-    ];
-
-    /**
-     * @return array<int,ConfigKeyEnum>
-     */
-    public static function getPathKeys(): array
-    {
-        return self::PATH_KEYS;
-    }
-
     /**
      * @return array<string,string>
      */

--- a/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
+++ b/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
@@ -30,10 +30,8 @@ class ConfigEnvironmentRender implements ConfigEnvironmentRenderInterface
         }
 
         $projectRoot = getenv(self::PROJECT_ROOT_ENV);
-        if (!is_string($projectRoot)) {
-            return '';
-        }
+        $projectRoot = is_string($projectRoot) ? trim($projectRoot) : '';
 
-        return $this->projectRootCache = trim($projectRoot);
+        return $this->projectRootCache = $projectRoot;
     }
 }

--- a/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
+++ b/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
@@ -18,6 +18,11 @@ class ConfigEnvironmentRender implements ConfigEnvironmentRenderInterface
         return str_replace(self::PROJECT_ROOT_PLACEHOLDER, $projectRoot, $path);
     }
 
+    public function renderRelativeProjectRoot(string $path): string
+    {
+        return str_replace(self::PROJECT_ROOT_PLACEHOLDER, '', $path);
+    }
+
     private function getProjectRoot(): string
     {
         self::$projectRoot = (string)getenv(self::PROJECT_ROOT_ENV);

--- a/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
+++ b/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
@@ -9,7 +9,7 @@ class ConfigEnvironmentRender implements ConfigEnvironmentRenderInterface
     private const string PROJECT_ROOT_PLACEHOLDER = '${PROJECT_ROOT}';
     private const string PROJECT_ROOT_ENV = 'PROJECT_ROOT';
 
-    private static string $projectRoot;
+    private string $projectRootCache;
 
     public function renderProjectRoot(string $path): string
     {
@@ -25,8 +25,15 @@ class ConfigEnvironmentRender implements ConfigEnvironmentRenderInterface
 
     private function getProjectRoot(): string
     {
-        self::$projectRoot = (string)getenv(self::PROJECT_ROOT_ENV);
+        if (isset($this->projectRootCache)) {
+            return $this->projectRootCache;
+        }
 
-        return self::$projectRoot;
+        $projectRoot = getenv(self::PROJECT_ROOT_ENV);
+        if (!is_string($projectRoot)) {
+            return '';
+        }
+
+        return $this->projectRootCache = trim($projectRoot);
     }
 }

--- a/src/TransferGenerator/Config/Environment/ConfigEnvironmentRenderInterface.php
+++ b/src/TransferGenerator/Config/Environment/ConfigEnvironmentRenderInterface.php
@@ -7,4 +7,6 @@ namespace Picamator\TransferObject\TransferGenerator\Config\Environment;
 interface ConfigEnvironmentRenderInterface
 {
     public function renderProjectRoot(string $path): string;
+
+    public function renderRelativeProjectRoot(string $path): string;
 }

--- a/src/TransferGenerator/Config/Parser/ConfigContentBuilder.php
+++ b/src/TransferGenerator/Config/Parser/ConfigContentBuilder.php
@@ -33,10 +33,12 @@ readonly class ConfigContentBuilder implements ConfigContentBuilderInterface
 
     private function renderPathKeys(ConfigContentTransfer $contentTransfer): ConfigContentTransfer
     {
+        $contentTransfer->relativeDefinitionPath =
+            $this->environmentRender->renderRelativeProjectRoot($contentTransfer->definitionPath);
+
         foreach (ConfigKeyEnum::getPathKeys() as $key) {
-            $contentTransfer->{$key->value} = $this->environmentRender->renderProjectRoot(
-                $contentTransfer->{$key->value},
-            );
+            $contentTransfer->{$key->value} = $this->environmentRender
+                ->renderProjectRoot($contentTransfer->{$key->value});
         }
 
         return $contentTransfer;

--- a/src/TransferGenerator/Config/Parser/ConfigContentBuilder.php
+++ b/src/TransferGenerator/Config/Parser/ConfigContentBuilder.php
@@ -36,10 +36,11 @@ readonly class ConfigContentBuilder implements ConfigContentBuilderInterface
         $contentTransfer->relativeDefinitionPath =
             $this->environmentRender->renderRelativeProjectRoot($contentTransfer->definitionPath);
 
-        foreach (ConfigKeyEnum::getPathKeys() as $key) {
-            $contentTransfer->{$key->value} = $this->environmentRender
-                ->renderProjectRoot($contentTransfer->{$key->value});
-        }
+        $contentTransfer->definitionPath =
+            $this->environmentRender->renderProjectRoot($contentTransfer->definitionPath);
+
+        $contentTransfer->transferPath =
+            $this->environmentRender->renderProjectRoot($contentTransfer->transferPath);
 
         return $contentTransfer;
     }

--- a/src/TransferGenerator/Generator/Render/TemplateBuilder.php
+++ b/src/TransferGenerator/Generator/Render/TemplateBuilder.php
@@ -43,9 +43,6 @@ readonly class TemplateBuilder implements TemplateBuilderInterface
 
     private function getDefinitionPath(DefinitionTransfer $definitionTransfer): string
     {
-        $workingDirectory = getcwd() ?: '';
-        $definitionPath = str_replace($workingDirectory, '', $this->config->getDefinitionPath());
-
-        return $definitionPath . DIRECTORY_SEPARATOR . $definitionTransfer->fileName;
+        return $this->config->getRelativeDefinitionPath() . DIRECTORY_SEPARATOR . $definitionTransfer->fileName;
     }
 }

--- a/src/TransferGenerator/TransferGeneratorFacadeInterface.php
+++ b/src/TransferGenerator/TransferGeneratorFacadeInterface.php
@@ -20,7 +20,7 @@ interface TransferGeneratorFacadeInterface
      *
      * @api
      *
-     * @example ./src/Command/TransferGeneratorCommand.php
+     * @example /src/Command/TransferGeneratorCommand.php
      *
      * @throws \Picamator\TransferObject\Shared\Exception\TransferExceptionInterface
      * @throws \FiberError
@@ -39,8 +39,8 @@ interface TransferGeneratorFacadeInterface
      *
      * @api
      *
-     * @example ./doc/samples/try-transfer-generator.php
-     * @example ./doc/samples/try-advanced-transfer-generator.php
+     * @example /doc/samples/try-transfer-generator.php
+     * @example /doc/samples/try-advanced-transfer-generator.php
      *
      * @throws \Picamator\TransferObject\Shared\Exception\TransferExceptionInterface
      */

--- a/tests/integration/Command/DefinitionGeneratorCommandTest.php
+++ b/tests/integration/Command/DefinitionGeneratorCommandTest.php
@@ -40,7 +40,7 @@ class DefinitionGeneratorCommandTest extends TestCase
         // Assert
         $this->assertSame(0, $this->commandTester->getStatusCode());
         $this->assertStringContainsString(
-            'Definition files 1 were generated successfully.',
+            'Successfully generated 1 definition file(s)!',
             $output,
         );
         $this->assertFileExists(__DIR__ . '/Generated/Definition/customer.transfer.yml');

--- a/tests/integration/Command/TransferGeneratorCommandTest.php
+++ b/tests/integration/Command/TransferGeneratorCommandTest.php
@@ -30,7 +30,7 @@ class TransferGeneratorCommandTest extends TestCase
 
         // Assert
         $this->assertSame(1, $this->commandTester->getStatusCode());
-        $this->assertStringContainsString('Command option -c is not set.', $output);
+        $this->assertStringContainsString('The required -c option is missing.', $output);
     }
 
     public function testRunCommandWithInvalidConfigurationPathShouldShowErrorMessage(): void
@@ -59,7 +59,7 @@ class TransferGeneratorCommandTest extends TestCase
 
         // Assert
         $this->commandTester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('Transfer Objects were generated successfully.', $output);
+        $this->assertStringContainsString('All Transfer Objects were generated successfully!', $output);
     }
 
     public function testRunCommandWithValidConfigurationButInvalidDefinitionShouldShowErrorMessage(): void


### PR DESCRIPTION
Release 2.0.2
=====================

Description
-----------

1. Fixed definition path doc-block inconsistency issue, after running transfer object generation command in diferent context e.g.  sample or phpunit
2. Fixed transfer object configuration cache
3. Actualized console commands and composer scripts descriptions
4. Reformat `composer.json`
5. Marked more classses with `@api` doc-block

Type of Change
--------------

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

Checklist
---------

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [x] I agree to follow this project's [Code of Conduct](https://github.com/picamator/transfer-object/blob/main/CODE_OF_CONDUCT.md).
