### PR TITLE
Release 2.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Generate Transfer Objects
         env:
           PROJECT_ROOT: ${{ github.workspace }}
-        run: composer transfer-generate -- -c ${PROJECT_ROOT}/config/generator.config.yml
+        run: composer transfer-generate -- -c /config/generator.config.yml
 
       - name: Run PHPUnit
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Generate Transfer Objects
         env:
           PROJECT_ROOT: ${{ github.workspace }}
-        run: composer transfer-generate -- -c /config/generator.config.yml
+        run: composer transfer-generate -- -c ./config/generator.config.yml
 
       - name: Run PHPUnit
         env:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Transfer Object Generator
 ==========================
 
 Would you like to build Symfony-compatible Transfer Objects easily?
+
 You're in the right place!
 
 Build Transfer Object by Blueprint
 ----------------------------------
 
 Imagine you have a Rest API response:
+
 ```json
 {
     "firstName": "Jan",
@@ -23,11 +25,13 @@ Imagine you have a Rest API response:
 ```
 
 Running the following interactive [console command](https://github.com/picamator/transfer-object/wiki/Console-Commands#definition-generate):
-```shell
+
+```console
 $ ./vendor/bin/definition-generate
 ```
 
 Generates a `YML` [definition file](https://github.com/picamator/transfer-object/wiki/Definition-File):
+
 ```yml
 Customer:
   firstName:
@@ -37,11 +41,13 @@ Customer:
 ```
 
 Then, running another [console command](https://github.com/picamator/transfer-object/wiki/Console-Commands#transfer-generate):
-```shell
+
+```console
 $ ./vendor/bin/transfer-generate [-c|--configuration CONFIGURATION]
 ```
 
 Builds the Transfer Object:
+
 ```php
 $customerTransfer = new CustomerTransfer();
 $customerTransfer->firstName = 'Jan';
@@ -58,17 +64,16 @@ Key Features
 * **Transfer Object:**
   * implements methods: `fromArray()`, `toArray()`, and `toFilterArray()`
   * implements standard interfaces: `IteratorAggregate`, `JsonSerializable`, and `Countable`
-  * supports nullable and not nullable property types
-  * supports asymmetric protected property `set` visibility
-  * supports `BackedEnum`
-  * compatible with custom Data Transfer Object (DTO)
+  * supports embedded Transfer Objects, collections as well as `BackedEnum`, nullable and not nullable property types
+  * supports asymmetric property visibility
+  * supports custom Data Transfer Object (DTO)
 
 Installation
 ------------
 
 Composer installation:
 
-```shell
+```console
 $ composer require picamator/transfer-object
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Key Features
 ------------
 
 * **Symfony-compatible:**
-  * includes Symfony commands: [TransferGeneratorCommand](/src/Command/TransferGeneratorCommand.php) and [DefinitionGeneratorCommand](/src/Command/DefinitionGeneratorCommand.php)
-  * includes Symfony like services: [TransferGeneratorFacade](/src/TransferGenerator/TransferGeneratorFacade.php) and [DefinitionGeneratorFacade](/src/DefinitionGenerator/DefinitionGeneratorFacade.php)
-  * mappable with Symfony request query string and payload
+  * includes Symfony console commands: [TransferGeneratorCommand](/src/Command/TransferGeneratorCommand.php) and [DefinitionGeneratorCommand](/src/Command/DefinitionGeneratorCommand.php)
+  * includes Symfony services: [TransferGeneratorFacade](/src/TransferGenerator/TransferGeneratorFacade.php) and [DefinitionGeneratorFacade](/src/DefinitionGenerator/DefinitionGeneratorFacade.php)
+  * Transfer Objects are mappable with Symfony request
 * **Transfer Object:**
   * implements methods: `fromArray()`, `toArray()`, and `toFilterArray()`
   * implements standard interfaces: `IteratorAggregate`, `JsonSerializable`, and `Countable`

--- a/README.md
+++ b/README.md
@@ -8,25 +8,26 @@
 Transfer Object Generator
 ==========================
 
-Would you like to build lightweight Symfony-compatible Transfer Objects (TO) easily?
+Would you like to build Symfony-compatible Transfer Objects easily?
 You're in the right place!
 
-Build TOs Using JSON as a Blueprint
-------------------------------------
+Build Transfer Object by Blueprint
+----------------------------------
 
-Imagine you have a Rest API `JSON` response:
+Imagine you have a Rest API response:
 ```json
 {
     "firstName": "Jan",
     "lastName": "Kowalski"
 }
 ```
-Running the following console command:
+
+Running the following interactive [console command](https://github.com/picamator/transfer-object/wiki/Console-Commands#definition-generate):
 ```shell
 $ ./vendor/bin/definition-generate
 ```
 
-Generates a `YML` definition file:
+Generates an `YML` [definition file](https://github.com/picamator/transfer-object/wiki/Definition-File):
 ```yml
 Customer:
   firstName:
@@ -35,12 +36,12 @@ Customer:
     type: string
 ```
 
-Then, running another console command:
+Then, running another [console command](https://github.com/picamator/transfer-object/wiki/Console-Commands#transfer-generate):
 ```shell
 $ ./vendor/bin/transfer-generate [-c|--configuration CONFIGURATION]
 ```
 
-Builds the TO:
+Builds the Transfer Object:
 ```php
 $customerTransfer = new CustomerTransfer();
 $customerTransfer->firstName = 'Jan';
@@ -50,16 +51,17 @@ $customerTransfer->lastName = 'Kowalski';
 Key Features
 ------------
 
-* **Symfony-compatible commands:**
-  * Includes [TransferGeneratorCommand](/src/Command/TransferGeneratorCommand.php) and [DefinitionGeneratorCommand](/src/Command/DefinitionGeneratorCommand.php) as Symfony commands
-  * [TransferGeneratorFacade](/src/TransferGenerator/TransferGeneratorFacade.php) and [DefinitionGeneratorFacade](/src/DefinitionGenerator/DefinitionGeneratorFacade.php) can be integrated as Symfony services
-* **Interface methods:** implements `fromArray()`, `toArray()`, `toFilterArray()`
-* **Standard interfaces:** implements `IteratorAggregate`, `JsonSerializable`, and `Countable`
-* **Lightweight:** TO includes only data without any business logic
-* **Nullable:** supports nullable and not nullable property types
-* **Protected** supports asymmetric visibility for properties `set`
-* **BackedEnum:** supports `BackedEnum`
-* **Adaptable:** compatible with custom Data Transfer Object (DTO) implementation
+* **Symfony-compatible:**
+  * includes Symfony commands: [TransferGeneratorCommand](/src/Command/TransferGeneratorCommand.php) and [DefinitionGeneratorCommand](/src/Command/DefinitionGeneratorCommand.php)
+  * includes Symfony like services: [TransferGeneratorFacade](/src/TransferGenerator/TransferGeneratorFacade.php) and [DefinitionGeneratorFacade](/src/DefinitionGenerator/DefinitionGeneratorFacade.php)
+  * mappable with Symfony request query string and payload
+* **Transfer Object:**
+  * implements methods: `fromArray()`, `toArray()`, and `toFilterArray()`
+  * implement standard interfaces: `IteratorAggregate`, `JsonSerializable`, and `Countable`
+  * supports nullable and not nullable property types
+  * supports asymmetric protected property `set` visibility
+  * supports `BackedEnum`
+  * compatible with custom Data Transfer Object (DTO) implementation
 
 Installation
 ------------
@@ -69,37 +71,6 @@ Composer installation:
 ```shell
 $ composer require picamator/transfer-object
 ```
-
-Usage
------
-
-### Terminal
-
-Run the following command to generate Transfer Objects:
-```shell
-$ ./vendor/bin/transfer-generate [-c|--configuration CONFIGURATION]
-```
-
-Run the following command to generate Definition Files:
-```shell
-$ ./vendor/bin/definition-generate
-```
-
-For more details, check the Wiki:
-- [Console Commands](https://github.com/picamator/transfer-object/wiki/Console-Commands)
-- [Definition File](https://github.com/picamator/transfer-object/wiki/Definition-File)
-
-### Facade Interface
-
-Please check Wiki:
-- [Facade Interfaces](https://github.com/picamator/transfer-object/wiki/Facade-Interfaces)
-- [Visualizing Diagrams](https://github.com/picamator/transfer-object/wiki/Visualising-Diagrams)
-
-Explore usage samples:
-- [Definition Generator](/doc/samples/try-definition-generator.php)
-- [Transfer Generator](/doc/samples/try-transfer-generator.php)
-- [Advanced Transfer Generator](/doc/samples/try-advanced-transfer-generator.php)
-
 
 Usage Tests
 -----------
@@ -114,16 +85,25 @@ Definition Files and Transfer Object generators have been tested against API res
 
 ### Test Scenario
 
-1. JSON response is used as a blueprint to generate Definition Files and then TOs.
-2. Generated TO instance is created with the `JSON` data.
-3. The TO instance is converted to an array by running the `toArray()` method.
-4. The converted array is compared to the decoded `JSON` blueprint.
+1. Rest API response is used as a blueprint to generate Definition Files
+2. Transfer Objects are generated based on Definition Files
+3. Transfer Object instance is created with the API response
+4. Transfer Object is converted back to array
+5. The converted array is compared with the API response
 
-In all cases the compared data were **100%** matched.
+In all cases data **100%** are matched.
 
-More details are in the integration test [DefinitionGeneratorFacadeTest](/tests/integration/DefinitionGenerator/DefinitionGeneratorFacadeTest.php).
+Please check [DefinitionGeneratorFacadeTest](/tests/integration/DefinitionGenerator/DefinitionGeneratorFacadeTest.php) for more details.
 
-Additionally, Definition Files and Transfer Object generators are using TOs.
+### Service Samples
+
+- [Definition Generator](/doc/samples/try-definition-generator.php)
+- [Transfer Generator](/doc/samples/try-transfer-generator.php)
+- [Advanced Transfer Generator](/doc/samples/try-advanced-transfer-generator.php)
+
+### Practice
+
+Definition Files and Transfer Objects generators use [Transfer Objects](/src/Generated).
 
 Acknowledgment
 --------------

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Definition Files and Transfer Objects generators use [Transfer Objects](/src/Gen
 Acknowledgment
 --------------
 
-Many thanks for your contribution, support, feedback and simply using the Transfer Object Generator! 💖
+Many thanks for your contribution, support, feedback and simply using the Transfer Object Generator! ❤️
 
 Contribution
 ------------
@@ -123,8 +123,8 @@ Follow the project to stay updated with all activities.
 
 If you have suggestions for improvements or new features, feel free to:
 
-- Create an issue 🐛
-- Submit a pull request 🚀
+- Create an issue
+- Submit a pull request
 
 Here is a [Contribution Guide](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Running the following interactive [console command](https://github.com/picamator
 $ ./vendor/bin/definition-generate
 ```
 
-Generates an `YML` [definition file](https://github.com/picamator/transfer-object/wiki/Definition-File):
+Generates a `YML` [definition file](https://github.com/picamator/transfer-object/wiki/Definition-File):
 ```yml
 Customer:
   firstName:
@@ -88,10 +88,10 @@ Definition Files and Transfer Object generators have been tested against API res
 1. Rest API response is used as a blueprint to generate Definition Files
 2. Transfer Objects are generated based on Definition Files
 3. Transfer Object instance is created with the API response
-4. Transfer Object is converted back to array
+4. Transfer Object is converted back to the array
 5. The converted array is compared with the API response
 
-In all cases data **100%** are matched.
+In all cases, data **100%** are matched.
 
 Please check [DefinitionGeneratorFacadeTest](/tests/integration/DefinitionGenerator/DefinitionGeneratorFacadeTest.php) for more details.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Key Features
   * mappable with Symfony request query string and payload
 * **Transfer Object:**
   * implements methods: `fromArray()`, `toArray()`, and `toFilterArray()`
-  * implement standard interfaces: `IteratorAggregate`, `JsonSerializable`, and `Countable`
+  * implements standard interfaces: `IteratorAggregate`, `JsonSerializable`, and `Countable`
   * supports nullable and not nullable property types
   * supports asymmetric protected property `set` visibility
   * supports `BackedEnum`
-  * compatible with custom Data Transfer Object (DTO) implementation
+  * compatible with custom Data Transfer Object (DTO)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Transfer Object Generator
 
 Would you like to build Symfony-compatible Transfer Objects easily?
 
-You're in the right place!
+You're in the right place! 🎉
 
 Build Transfer Object by Blueprint
 ----------------------------------
@@ -96,7 +96,7 @@ Definition Files and Transfer Object generators have been tested against API res
 4. Transfer Object is converted back to the array
 5. The converted array is compared with the API response
 
-In all cases, data **100%** are matched.
+In all cases, data **100%** are matched ✅.
 
 Please check [DefinitionGeneratorFacadeTest](/tests/integration/DefinitionGenerator/DefinitionGeneratorFacadeTest.php) for more details.
 
@@ -113,13 +113,19 @@ Definition Files and Transfer Objects generators use [Transfer Objects](/src/Gen
 Acknowledgment
 --------------
 
-Many thanks for your contribution, support, feedback and simply using the Transfer Object Generator!
+Many thanks for your contribution, support, feedback and simply using the Transfer Object Generator! 💖
 
 Contribution
 ------------
 
-If you find this project useful, please add a star to the repository. Follow the project to stay updated with all activities.
-If you have suggestions for improvements or new features, feel free to create an issue or submit a pull request.
+If you find this project useful, please ⭐ star the repository.
+Follow the project to stay updated with all activities.
+
+If you have suggestions for improvements or new features, feel free to:
+
+- Create an issue 🐛
+- Submit a pull request 🚀
+
 Here is a [Contribution Guide](CONTRIBUTING.md).
 
 

--- a/README.md
+++ b/README.md
@@ -130,4 +130,5 @@ License
 -------
 
 Transfer Object Generator is free and open-source software licensed under the MIT License.
+
 For more details, please see the [LICENSE](LICENSE) file.

--- a/docker/sdk
+++ b/docker/sdk
@@ -36,7 +36,6 @@ function show_usage() {
 
 # vars
 DOCKER_CONTAINER_NAME=transfer-object-php
-PROJECT_ROOT="/home/transfer/transfer-object"
 DOCKER_EXEC="docker exec -it ${DOCKER_CONTAINER_NAME}"
 
 # options
@@ -102,7 +101,7 @@ case $1 in
     $DOCKER_EXEC composer captainhook $2
     ;;
   to-generate)
-     $DOCKER_EXEC composer transfer-generate -- -c ${PROJECT_ROOT}/config/generator.config.yml
+     $DOCKER_EXEC composer transfer-generate -- -c /config/generator.config.yml
     ;;
   df-generate)
      $DOCKER_EXEC composer definition-generate

--- a/docker/sdk
+++ b/docker/sdk
@@ -101,7 +101,7 @@ case $1 in
     $DOCKER_EXEC composer captainhook $2
     ;;
   to-generate)
-     $DOCKER_EXEC composer transfer-generate -- -c /config/generator.config.yml
+     $DOCKER_EXEC composer transfer-generate -- -c ./config/generator.config.yml
     ;;
   df-generate)
      $DOCKER_EXEC composer definition-generate

--- a/src/Command/DefinitionGeneratorCommand.php
+++ b/src/Command/DefinitionGeneratorCommand.php
@@ -38,9 +38,9 @@ HELP;
     private const string QUESTION_CLASS_NAME = 'Transfer Object class name: ';
     private const string QUESTION_JSON_PATH = 'JSON file path: ';
 
-    private const string START_SECTION_NAME = 'Generating Transfer Object Definitions...';
+    private const string START_SECTION_NAME = 'Generating Transfer Object Definitions 🪄';
 
-    private const string SUCCESS_MESSAGE_TEMPLATE = 'Successfully generated %d definition file(s)!';
+    private const string SUCCESS_MESSAGE_TEMPLATE = 'Successfully generated %d definition file(s)! 🎉';
 
     public function __construct(
         ?string $name = null,

--- a/src/Command/Helper/InputNormalizerTrait.php
+++ b/src/Command/Helper/InputNormalizerTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picamator\TransferObject\Command\Helper;
+
+trait InputNormalizerTrait
+{
+    private function normalizePath(?string $value): string
+    {
+        $value = $this->normalizeEmpty($value);
+        if ($value === '') {
+            return '';
+        }
+
+        $workingDirectory = getcwd() ?: '';
+        $value = ltrim($value, '\/');
+
+        return $workingDirectory . DIRECTORY_SEPARATOR . $value;
+    }
+
+    private function normalizeEmpty(?string $value): string
+    {
+        return $value ? trim($value) : '';
+    }
+}

--- a/src/Command/Helper/InputNormalizerTrait.php
+++ b/src/Command/Helper/InputNormalizerTrait.php
@@ -16,7 +16,9 @@ trait InputNormalizerTrait
         $workingDirectory = getcwd() ?: '';
         $value = ltrim($value, '\/');
 
-        return $workingDirectory . DIRECTORY_SEPARATOR . $value;
+        $path = realpath($workingDirectory . DIRECTORY_SEPARATOR . $value);
+
+        return (string)$path;
     }
 
     private function normalizeEmpty(?string $value): string

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Command;
 
+use Picamator\TransferObject\Command\Helper\InputNormalizerTrait;
 use Picamator\TransferObject\Generated\TransferGeneratorTransfer;
 use Picamator\TransferObject\TransferGenerator\TransferGeneratorFacade;
 use Picamator\TransferObject\TransferGenerator\TransferGeneratorFacadeInterface;
@@ -15,6 +16,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class TransferGeneratorCommand extends Command
 {
+    use InputNormalizerTrait;
+
     private const string NAME = 'picamator:transfer:generate';
     private const string DESCRIPTION = 'Generate Transfer Objects from definition templates.';
     private const string HELP = <<<'HELP'
@@ -71,7 +74,7 @@ HELP;
         $styleOutput->section(self::START_SECTION_NAME);
 
         $configPath = $this->getConfigPath($input, $styleOutput);
-        if ($configPath === null) {
+        if ($configPath === '') {
             return Command::FAILURE;
         }
 
@@ -120,13 +123,13 @@ HELP;
         }
     }
 
-    private function getConfigPath(InputInterface $input, SymfonyStyle $styleOutput): ?string
+    private function getConfigPath(InputInterface $input, SymfonyStyle $styleOutput): string
     {
-        $configPath = $input->getOption(name: self::OPTION_NAME_CONFIGURATION) ?: '';
-        if ($configPath === '' || !is_string($configPath)) {
-            $styleOutput->error(self::ERROR_MISSED_OPTION_CONFIG_MESSAGE);
+        $configPath = $input->getOption(name: self::OPTION_NAME_CONFIGURATION);
+        $configPath = is_string($configPath) ? $this->normalizePath($configPath) : '';
 
-            return null;
+        if ($configPath === '') {
+            $styleOutput->error(self::ERROR_MISSED_OPTION_CONFIG_MESSAGE);
         }
 
         return $configPath;

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -34,7 +34,7 @@ HELP;
     private const string OPTION_SHORTCUT_CONFIGURATION = 'c';
     private const string OPTION_DESCRIPTION_CONFIGURATION = 'Path to the YML configuration file.';
 
-    private const string START_SECTION_NAME = 'Generating Transfer Objects...';
+    private const string START_SECTION_NAME = 'Generating Transfer Objects ✨';
 
     private const string ERROR_MISSED_OPTION_CONFIG_MESSAGE =
         'The required -c option is missing. Please provide the path to the YML configuration file.';
@@ -42,7 +42,7 @@ HELP;
     private const string TRANSFER_OBJECT_MESSAGE_TEMPLATE = 'Processing Transfer Object: "%s".';
     private const string DEFINITION_MESSAGE_TEMPLATE = 'Using definition file: "%s".';
 
-    private const string SUCCESS_MESSAGE = 'All Transfer Objects were generated successfully!';
+    private const string SUCCESS_MESSAGE = 'All Transfer Objects were generated successfully! 🎉';
 
     public function __construct(
         ?string $name = null,

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -36,8 +36,9 @@ HELP;
 
     private const string START_SECTION_NAME = 'Generating Transfer Objects ✨';
 
-    private const string ERROR_MISSED_OPTION_CONFIG_MESSAGE =
-        'The required -c option is missing. Please provide the path to the YML configuration file.';
+    private const string ERROR_MISSED_OPTION_CONFIG_MESSAGE = <<<'MESSAGE'
+The required -c option is missing or path does not exist. Please provide the path to the YML configuration file.
+MESSAGE;
 
     private const string TRANSFER_OBJECT_MESSAGE_TEMPLATE = 'Processing Transfer Object: "%s".';
     private const string DEFINITION_MESSAGE_TEMPLATE = 'Using definition file: "%s".';

--- a/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
+++ b/src/TransferGenerator/Config/Environment/ConfigEnvironmentRender.php
@@ -29,9 +29,20 @@ class ConfigEnvironmentRender implements ConfigEnvironmentRenderInterface
             return $this->projectRootCache;
         }
 
-        $projectRoot = getenv(self::PROJECT_ROOT_ENV);
-        $projectRoot = is_string($projectRoot) ? trim($projectRoot) : '';
+        $projectRoot = $this->getEnv(self::PROJECT_ROOT_ENV) ?: $this->getCwd();
 
         return $this->projectRootCache = $projectRoot;
+    }
+
+    protected function getCwd(): string
+    {
+        return getcwd() ?: '';
+    }
+
+    protected function getEnv(string $name): string
+    {
+        $envValue = getenv($name);
+
+        return is_string($envValue) ? trim($envValue) : '';
     }
 }

--- a/tests/integration/Command/TransferGeneratorCommandTest.php
+++ b/tests/integration/Command/TransferGeneratorCommandTest.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class TransferGeneratorCommandTest extends TestCase
 {
-    private const string SUCCESS_CONFIG_PATH = __DIR__ . '/data/config/success/generator.config.yml';
-    private const string ERROR_CONFIG_PATH = __DIR__ . '/data/config/error/generator.config.yml';
+    private const string SUCCESS_CONFIG_PATH = '/tests/integration/Command/data/config/success/generator.config.yml';
+    private const string ERROR_CONFIG_PATH = '/tests/integration/Command/data/config/error/generator.config.yml';
 
     private CommandTester $commandTester;
 
@@ -36,25 +36,18 @@ class TransferGeneratorCommandTest extends TestCase
     public function testRunCommandWithInvalidConfigurationPathShouldShowErrorMessage(): void
     {
         // Act
-        $this->commandTester->execute([
-            '-c' => 'some-invalid-path.config.yml'
-        ]);
+        $this->commandTester->execute(['-c' => 'some-invalid-path.config.yml']);
         $output = $this->commandTester->getDisplay();
 
         // Assert
         $this->assertSame(1, $this->commandTester->getStatusCode());
-        $this->assertStringContainsString(
-            'Path "some-invalid-path.config.yml" does not exist.',
-            $output,
-        );
+        $this->assertStringContainsString('not exist.', $output);
     }
 
     public function testRunCommandWithValidConfigurationShouldShowSuccessMessage(): void
     {
         // Act
-        $this->commandTester->execute([
-            '-c' => self::SUCCESS_CONFIG_PATH,
-        ]);
+        $this->commandTester->execute(['-c' => self::SUCCESS_CONFIG_PATH]);
         $output = $this->commandTester->getDisplay();
 
         // Assert
@@ -65,9 +58,7 @@ class TransferGeneratorCommandTest extends TestCase
     public function testRunCommandWithValidConfigurationButInvalidDefinitionShouldShowErrorMessage(): void
     {
         // Act
-        $this->commandTester->execute([
-            '-c' => self::ERROR_CONFIG_PATH,
-        ]);
+        $this->commandTester->execute(['-c' => self::ERROR_CONFIG_PATH]);
         $output = $this->commandTester->getDisplay();
 
         // Assert

--- a/tests/integration/Command/TransferGeneratorCommandTest.php
+++ b/tests/integration/Command/TransferGeneratorCommandTest.php
@@ -30,7 +30,7 @@ class TransferGeneratorCommandTest extends TestCase
 
         // Assert
         $this->assertSame(1, $this->commandTester->getStatusCode());
-        $this->assertStringContainsString('The required -c option is missing.', $output);
+        $this->assertStringContainsString('The required -c option is missing or path does not exist.', $output);
     }
 
     public function testRunCommandWithInvalidConfigurationPathShouldShowErrorMessage(): void


### PR DESCRIPTION
Release 2.0.3
========

Description
------------

1. Simplified readme
2. Refactored Transfer Object and Definition Files generator console commands
3. Fixed issue with resolving configuration path on Transfer Object console command
4. Added fallback to working directory when environment variable `PROJECT_ROOT` is not set

Type of Change
-----------------

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

Checklist
---------

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [x] I agree to follow this project's [Code of Conduct](https://github.com/picamator/transfer-object/blob/main/CODE_OF_CONDUCT.md).
