### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Key Features
 * Offers methods:
   * `fromArray()`
   * `toArray()`
-  * `toFilterArray()`
 * Implements standard interfaces:
   * `IteratorAggregate`
   * `JsonSerializable`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI workflow](https://github.com/picamator/transfer-object/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/picamator/transfer-object/actions)
 [![License](https://poser.pugx.org/picamator/transfer-object/license)](https://packagist.org/packages/picamator/transfer-object)
 [![PHP Version Require](https://poser.pugx.org/picamator/transfer-object/require/php)](https://packagist.org/packages/picamator/transfer-object)
-[![Symfony Compatibility](https://img.shields.io/badge/Symfony-%5E7.0-blue)](https://github.com/picamator/transfer-object/tree/development?tab=readme-ov-file#key-features)
+[![Symfony Compatibility](https://img.shields.io/badge/Symfony-%5E7.3-blue)](https://github.com/picamator/transfer-object/tree/development?tab=readme-ov-file#key-features)
 [![Wiki](https://img.shields.io/badge/wiki-available-brightgreen)](https://github.com/picamator/transfer-object/wiki)
 [![Latest Stable Version](https://poser.pugx.org/picamator/transfer-object/v)](https://packagist.org/packages/picamator/transfer-object)
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Sergii Pryz",
-            "role": "Developer"
+            "name": "Sergii Pryz"
         },
         {
             "name": "Community",
@@ -42,10 +41,10 @@
         "php": ">=8.4",
         "composer-runtime-api": "^2.2",
         "psr/container": "^2.0",
-        "symfony/console": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/finder": "^7.0",
-        "symfony/yaml": "^7.0"
+        "symfony/console": "^7.3",
+        "symfony/filesystem": "^7.3",
+        "symfony/finder": "^7.3",
+        "symfony/yaml": "^7.3"
     },
     "require-dev": {
         "captainhook/captainhook": "^5.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f90bf91411f6f5c6e21d756d23aa52f7",
+    "content-hash": "8b294801801c6606d4ca2aec7ff85fcd",
     "packages": [
         {
             "name": "psr/container",
@@ -2015,16 +2015,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c"
+                "reference": "8fd93be538992d556aaa45c74570129448a42084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/6d584c727d9114bcdc14c86711cd1cad51778e7c",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/8fd93be538992d556aaa45c74570129448a42084",
+                "reference": "8fd93be538992d556aaa45c74570129448a42084",
                 "shasum": ""
             },
             "require": {
@@ -2036,7 +2036,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2060,15 +2060,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.1.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:53:50+00:00"
+            "time": "2025-09-13T14:16:18+00:00"
         },
         {
             "name": "sebastian/comparator",

--- a/examples/Generated/AdvancedTransferGenerator/AdvancedCustomerTransfer.php
+++ b/examples/Generated/AdvancedTransferGenerator/AdvancedCustomerTransfer.php
@@ -25,41 +25,38 @@ final class AdvancedCustomerTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::ADDRESS => self::ADDRESS_DATA_NAME,
-        self::CREDENTIALS => self::CREDENTIALS_DATA_NAME,
-        self::CUSTOMER => self::CUSTOMER_DATA_NAME,
+        self::ADDRESS_INDEX => self::ADDRESS,
+        self::CREDENTIALS_INDEX => self::CREDENTIALS,
+        self::CUSTOMER_INDEX => self::CUSTOMER,
     ];
 
     // address
     #[PropertyTypeAttribute(AddressData::class)]
     public const string ADDRESS = 'address';
-    protected const string ADDRESS_DATA_NAME = 'ADDRESS';
-    protected const int ADDRESS_DATA_INDEX = 0;
+    protected const int ADDRESS_INDEX = 0;
 
     public TransferInterface&AddressData $address {
-        get => $this->getData(self::ADDRESS_DATA_INDEX);
-        set => $this->setData(self::ADDRESS_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS_INDEX);
+        set => $this->setData(self::ADDRESS_INDEX, $value);
     }
 
     // credentials
     #[PropertyTypeAttribute(CredentialsData::class)]
     public const string CREDENTIALS = 'credentials';
-    protected const string CREDENTIALS_DATA_NAME = 'CREDENTIALS';
-    protected const int CREDENTIALS_DATA_INDEX = 1;
+    protected const int CREDENTIALS_INDEX = 1;
 
     public TransferInterface&CredentialsData $credentials {
-        get => $this->getData(self::CREDENTIALS_DATA_INDEX);
-        set => $this->setData(self::CREDENTIALS_DATA_INDEX, $value);
+        get => $this->getData(self::CREDENTIALS_INDEX);
+        set => $this->setData(self::CREDENTIALS_INDEX, $value);
     }
 
     // customer
     #[PropertyTypeAttribute(CustomerTransfer::class)]
     public const string CUSTOMER = 'customer';
-    protected const string CUSTOMER_DATA_NAME = 'CUSTOMER';
-    protected const int CUSTOMER_DATA_INDEX = 2;
+    protected const int CUSTOMER_INDEX = 2;
 
     public TransferInterface&CustomerTransfer $customer {
-        get => $this->getData(self::CUSTOMER_DATA_INDEX);
-        set => $this->setData(self::CUSTOMER_DATA_INDEX, $value);
+        get => $this->getData(self::CUSTOMER_INDEX);
+        set => $this->setData(self::CUSTOMER_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/AvailabilitiesTransfer.php
+++ b/examples/Generated/DefinitionGenerator/AvailabilitiesTransfer.php
@@ -20,27 +20,25 @@ final class AvailabilitiesTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::BUFFER => self::BUFFER_DATA_NAME,
-        self::TOTAL => self::TOTAL_DATA_NAME,
+        self::BUFFER_INDEX => self::BUFFER,
+        self::TOTAL_INDEX => self::TOTAL,
     ];
 
     // buffer
     public const string BUFFER = 'buffer';
-    protected const string BUFFER_DATA_NAME = 'BUFFER';
-    protected const int BUFFER_DATA_INDEX = 0;
+    protected const int BUFFER_INDEX = 0;
 
     public ?int $buffer {
-        get => $this->getData(self::BUFFER_DATA_INDEX);
-        set => $this->setData(self::BUFFER_DATA_INDEX, $value);
+        get => $this->getData(self::BUFFER_INDEX);
+        set => $this->setData(self::BUFFER_INDEX, $value);
     }
 
     // total
     public const string TOTAL = 'total';
-    protected const string TOTAL_DATA_NAME = 'TOTAL';
-    protected const int TOTAL_DATA_INDEX = 1;
+    protected const int TOTAL_INDEX = 1;
 
     public ?int $total {
-        get => $this->getData(self::TOTAL_DATA_INDEX);
-        set => $this->setData(self::TOTAL_DATA_INDEX, $value);
+        get => $this->getData(self::TOTAL_INDEX);
+        set => $this->setData(self::TOTAL_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/BoxTransfer.php
+++ b/examples/Generated/DefinitionGenerator/BoxTransfer.php
@@ -20,27 +20,25 @@ final class BoxTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ITEMS => self::ITEMS_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::ITEMS_INDEX => self::ITEMS,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // items
     public const string ITEMS = 'items';
-    protected const string ITEMS_DATA_NAME = 'ITEMS';
-    protected const int ITEMS_DATA_INDEX = 0;
+    protected const int ITEMS_INDEX = 0;
 
     public ?int $items {
-        get => $this->getData(self::ITEMS_DATA_INDEX);
-        set => $this->setData(self::ITEMS_DATA_INDEX, $value);
+        get => $this->getData(self::ITEMS_INDEX);
+        set => $this->setData(self::ITEMS_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 1;
+    protected const int TYPE_INDEX = 1;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/DeliveryOptionsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/DeliveryOptionsTransfer.php
@@ -20,16 +20,15 @@ final class DeliveryOptionsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::NAME => self::NAME_DATA_NAME,
+        self::NAME_INDEX => self::NAME,
     ];
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 0;
+    protected const int NAME_INDEX = 0;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/DetailsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/DetailsTransfer.php
@@ -20,27 +20,25 @@ final class DetailsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::DESCRIPTION => self::DESCRIPTION_DATA_NAME,
-        self::IS_REGIONAL => self::IS_REGIONAL_DATA_NAME,
+        self::DESCRIPTION_INDEX => self::DESCRIPTION,
+        self::IS_REGIONAL_INDEX => self::IS_REGIONAL,
     ];
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const string DESCRIPTION_DATA_NAME = 'DESCRIPTION';
-    protected const int DESCRIPTION_DATA_INDEX = 0;
+    protected const int DESCRIPTION_INDEX = 0;
 
     public ?string $description {
-        get => $this->getData(self::DESCRIPTION_DATA_INDEX);
-        set => $this->setData(self::DESCRIPTION_DATA_INDEX, $value);
+        get => $this->getData(self::DESCRIPTION_INDEX);
+        set => $this->setData(self::DESCRIPTION_INDEX, $value);
     }
 
     // isRegional
     public const string IS_REGIONAL = 'isRegional';
-    protected const string IS_REGIONAL_DATA_NAME = 'IS_REGIONAL';
-    protected const int IS_REGIONAL_DATA_INDEX = 1;
+    protected const int IS_REGIONAL_INDEX = 1;
 
     public ?bool $isRegional {
-        get => $this->getData(self::IS_REGIONAL_DATA_INDEX);
-        set => $this->setData(self::IS_REGIONAL_DATA_INDEX, $value);
+        get => $this->getData(self::IS_REGIONAL_INDEX);
+        set => $this->setData(self::IS_REGIONAL_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/LabelsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/LabelsTransfer.php
@@ -20,16 +20,15 @@ final class LabelsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::SALE => self::SALE_DATA_NAME,
+        self::SALE_INDEX => self::SALE,
     ];
 
     // sale
     public const string SALE = 'sale';
-    protected const string SALE_DATA_NAME = 'SALE';
-    protected const int SALE_DATA_INDEX = 0;
+    protected const int SALE_INDEX = 0;
 
     public ?string $sale {
-        get => $this->getData(self::SALE_DATA_INDEX);
-        set => $this->setData(self::SALE_DATA_INDEX, $value);
+        get => $this->getData(self::SALE_INDEX);
+        set => $this->setData(self::SALE_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/MeasurementUnitTransfer.php
+++ b/examples/Generated/DefinitionGenerator/MeasurementUnitTransfer.php
@@ -21,29 +21,27 @@ final class MeasurementUnitTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::BOX => self::BOX_DATA_NAME,
-        self::PALETTE => self::PALETTE_DATA_NAME,
+        self::BOX_INDEX => self::BOX,
+        self::PALETTE_INDEX => self::PALETTE,
     ];
 
     // box
     #[PropertyTypeAttribute(BoxTransfer::class)]
     public const string BOX = 'box';
-    protected const string BOX_DATA_NAME = 'BOX';
-    protected const int BOX_DATA_INDEX = 0;
+    protected const int BOX_INDEX = 0;
 
     public ?BoxTransfer $box {
-        get => $this->getData(self::BOX_DATA_INDEX);
-        set => $this->setData(self::BOX_DATA_INDEX, $value);
+        get => $this->getData(self::BOX_INDEX);
+        set => $this->setData(self::BOX_INDEX, $value);
     }
 
     // palette
     #[PropertyTypeAttribute(PaletteTransfer::class)]
     public const string PALETTE = 'palette';
-    protected const string PALETTE_DATA_NAME = 'PALETTE';
-    protected const int PALETTE_DATA_INDEX = 1;
+    protected const int PALETTE_INDEX = 1;
 
     public ?PaletteTransfer $palette {
-        get => $this->getData(self::PALETTE_DATA_INDEX);
-        set => $this->setData(self::PALETTE_DATA_INDEX, $value);
+        get => $this->getData(self::PALETTE_INDEX);
+        set => $this->setData(self::PALETTE_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/PaletteTransfer.php
+++ b/examples/Generated/DefinitionGenerator/PaletteTransfer.php
@@ -20,27 +20,25 @@ final class PaletteTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ITEMS => self::ITEMS_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::ITEMS_INDEX => self::ITEMS,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // items
     public const string ITEMS = 'items';
-    protected const string ITEMS_DATA_NAME = 'ITEMS';
-    protected const int ITEMS_DATA_INDEX = 0;
+    protected const int ITEMS_INDEX = 0;
 
     public ?int $items {
-        get => $this->getData(self::ITEMS_DATA_INDEX);
-        set => $this->setData(self::ITEMS_DATA_INDEX, $value);
+        get => $this->getData(self::ITEMS_INDEX);
+        set => $this->setData(self::ITEMS_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 1;
+    protected const int TYPE_INDEX = 1;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/examples/Generated/DefinitionGenerator/ProductTransfer.php
+++ b/examples/Generated/DefinitionGenerator/ProductTransfer.php
@@ -24,146 +24,134 @@ final class ProductTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 12;
 
     protected const array META_DATA = [
-        self::AVAILABILITIES => self::AVAILABILITIES_DATA_NAME,
-        self::CURRENCY => self::CURRENCY_DATA_NAME,
-        self::DELIVERY_OPTIONS => self::DELIVERY_OPTIONS_DATA_NAME,
-        self::DETAILS => self::DETAILS_DATA_NAME,
-        self::IS_DISCOUNTED => self::IS_DISCOUNTED_DATA_NAME,
-        self::LABELS => self::LABELS_DATA_NAME,
-        self::MEASUREMENT_UNIT => self::MEASUREMENT_UNIT_DATA_NAME,
-        self::NAME => self::NAME_DATA_NAME,
-        self::PRICE => self::PRICE_DATA_NAME,
-        self::SKU => self::SKU_DATA_NAME,
-        self::STOCK => self::STOCK_DATA_NAME,
-        self::STORES => self::STORES_DATA_NAME,
+        self::AVAILABILITIES_INDEX => self::AVAILABILITIES,
+        self::CURRENCY_INDEX => self::CURRENCY,
+        self::DELIVERY_OPTIONS_INDEX => self::DELIVERY_OPTIONS,
+        self::DETAILS_INDEX => self::DETAILS,
+        self::IS_DISCOUNTED_INDEX => self::IS_DISCOUNTED,
+        self::LABELS_INDEX => self::LABELS,
+        self::MEASUREMENT_UNIT_INDEX => self::MEASUREMENT_UNIT,
+        self::NAME_INDEX => self::NAME,
+        self::PRICE_INDEX => self::PRICE,
+        self::SKU_INDEX => self::SKU,
+        self::STOCK_INDEX => self::STOCK,
+        self::STORES_INDEX => self::STORES,
     ];
 
     // availabilities
     #[CollectionPropertyTypeAttribute(AvailabilitiesTransfer::class)]
     public const string AVAILABILITIES = 'availabilities';
-    protected const string AVAILABILITIES_DATA_NAME = 'AVAILABILITIES';
-    protected const int AVAILABILITIES_DATA_INDEX = 0;
+    protected const int AVAILABILITIES_INDEX = 0;
 
     /** @var \ArrayObject<int,AvailabilitiesTransfer> */
     public ArrayObject $availabilities {
-        get => $this->getData(self::AVAILABILITIES_DATA_INDEX);
-        set => $this->setData(self::AVAILABILITIES_DATA_INDEX, $value);
+        get => $this->getData(self::AVAILABILITIES_INDEX);
+        set => $this->setData(self::AVAILABILITIES_INDEX, $value);
     }
 
     // currency
     public const string CURRENCY = 'currency';
-    protected const string CURRENCY_DATA_NAME = 'CURRENCY';
-    protected const int CURRENCY_DATA_INDEX = 1;
+    protected const int CURRENCY_INDEX = 1;
 
     public ?string $currency {
-        get => $this->getData(self::CURRENCY_DATA_INDEX);
-        set => $this->setData(self::CURRENCY_DATA_INDEX, $value);
+        get => $this->getData(self::CURRENCY_INDEX);
+        set => $this->setData(self::CURRENCY_INDEX, $value);
     }
 
     // deliveryOptions
     #[CollectionPropertyTypeAttribute(DeliveryOptionsTransfer::class)]
     public const string DELIVERY_OPTIONS = 'deliveryOptions';
-    protected const string DELIVERY_OPTIONS_DATA_NAME = 'DELIVERY_OPTIONS';
-    protected const int DELIVERY_OPTIONS_DATA_INDEX = 2;
+    protected const int DELIVERY_OPTIONS_INDEX = 2;
 
     /** @var \ArrayObject<int,DeliveryOptionsTransfer> */
     public ArrayObject $deliveryOptions {
-        get => $this->getData(self::DELIVERY_OPTIONS_DATA_INDEX);
-        set => $this->setData(self::DELIVERY_OPTIONS_DATA_INDEX, $value);
+        get => $this->getData(self::DELIVERY_OPTIONS_INDEX);
+        set => $this->setData(self::DELIVERY_OPTIONS_INDEX, $value);
     }
 
     // details
     #[PropertyTypeAttribute(DetailsTransfer::class)]
     public const string DETAILS = 'details';
-    protected const string DETAILS_DATA_NAME = 'DETAILS';
-    protected const int DETAILS_DATA_INDEX = 3;
+    protected const int DETAILS_INDEX = 3;
 
     public ?DetailsTransfer $details {
-        get => $this->getData(self::DETAILS_DATA_INDEX);
-        set => $this->setData(self::DETAILS_DATA_INDEX, $value);
+        get => $this->getData(self::DETAILS_INDEX);
+        set => $this->setData(self::DETAILS_INDEX, $value);
     }
 
     // isDiscounted
     public const string IS_DISCOUNTED = 'isDiscounted';
-    protected const string IS_DISCOUNTED_DATA_NAME = 'IS_DISCOUNTED';
-    protected const int IS_DISCOUNTED_DATA_INDEX = 4;
+    protected const int IS_DISCOUNTED_INDEX = 4;
 
     public ?bool $isDiscounted {
-        get => $this->getData(self::IS_DISCOUNTED_DATA_INDEX);
-        set => $this->setData(self::IS_DISCOUNTED_DATA_INDEX, $value);
+        get => $this->getData(self::IS_DISCOUNTED_INDEX);
+        set => $this->setData(self::IS_DISCOUNTED_INDEX, $value);
     }
 
     // labels
     #[PropertyTypeAttribute(LabelsTransfer::class)]
     public const string LABELS = 'labels';
-    protected const string LABELS_DATA_NAME = 'LABELS';
-    protected const int LABELS_DATA_INDEX = 5;
+    protected const int LABELS_INDEX = 5;
 
     public ?LabelsTransfer $labels {
-        get => $this->getData(self::LABELS_DATA_INDEX);
-        set => $this->setData(self::LABELS_DATA_INDEX, $value);
+        get => $this->getData(self::LABELS_INDEX);
+        set => $this->setData(self::LABELS_INDEX, $value);
     }
 
     // measurementUnit
     #[PropertyTypeAttribute(MeasurementUnitTransfer::class)]
     public const string MEASUREMENT_UNIT = 'measurementUnit';
-    protected const string MEASUREMENT_UNIT_DATA_NAME = 'MEASUREMENT_UNIT';
-    protected const int MEASUREMENT_UNIT_DATA_INDEX = 6;
+    protected const int MEASUREMENT_UNIT_INDEX = 6;
 
     public ?MeasurementUnitTransfer $measurementUnit {
-        get => $this->getData(self::MEASUREMENT_UNIT_DATA_INDEX);
-        set => $this->setData(self::MEASUREMENT_UNIT_DATA_INDEX, $value);
+        get => $this->getData(self::MEASUREMENT_UNIT_INDEX);
+        set => $this->setData(self::MEASUREMENT_UNIT_INDEX, $value);
     }
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 7;
+    protected const int NAME_INDEX = 7;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 
     // price
     public const string PRICE = 'price';
-    protected const string PRICE_DATA_NAME = 'PRICE';
-    protected const int PRICE_DATA_INDEX = 8;
+    protected const int PRICE_INDEX = 8;
 
     public ?float $price {
-        get => $this->getData(self::PRICE_DATA_INDEX);
-        set => $this->setData(self::PRICE_DATA_INDEX, $value);
+        get => $this->getData(self::PRICE_INDEX);
+        set => $this->setData(self::PRICE_INDEX, $value);
     }
 
     // sku
     public const string SKU = 'sku';
-    protected const string SKU_DATA_NAME = 'SKU';
-    protected const int SKU_DATA_INDEX = 9;
+    protected const int SKU_INDEX = 9;
 
     public ?string $sku {
-        get => $this->getData(self::SKU_DATA_INDEX);
-        set => $this->setData(self::SKU_DATA_INDEX, $value);
+        get => $this->getData(self::SKU_INDEX);
+        set => $this->setData(self::SKU_INDEX, $value);
     }
 
     // stock
     public const string STOCK = 'stock';
-    protected const string STOCK_DATA_NAME = 'STOCK';
-    protected const int STOCK_DATA_INDEX = 10;
+    protected const int STOCK_INDEX = 10;
 
     public ?int $stock {
-        get => $this->getData(self::STOCK_DATA_INDEX);
-        set => $this->setData(self::STOCK_DATA_INDEX, $value);
+        get => $this->getData(self::STOCK_INDEX);
+        set => $this->setData(self::STOCK_INDEX, $value);
     }
 
     // stores
     #[ArrayPropertyTypeAttribute]
     public const string STORES = 'stores';
-    protected const string STORES_DATA_NAME = 'STORES';
-    protected const int STORES_DATA_INDEX = 11;
+    protected const int STORES_INDEX = 11;
 
     /** @var array<int|string,mixed> */
     public array $stores {
-        get => $this->getData(self::STORES_DATA_INDEX);
-        set => $this->setData(self::STORES_DATA_INDEX, $value);
+        get => $this->getData(self::STORES_INDEX);
+        set => $this->setData(self::STORES_INDEX, $value);
     }
 }

--- a/examples/Generated/TransferGenerator/AgentTransfer.php
+++ b/examples/Generated/TransferGenerator/AgentTransfer.php
@@ -23,30 +23,28 @@ final class AgentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CUSTOMER => self::CUSTOMER_DATA_NAME,
-        self::MERCHANTS => self::MERCHANTS_DATA_NAME,
+        self::CUSTOMER_INDEX => self::CUSTOMER,
+        self::MERCHANTS_INDEX => self::MERCHANTS,
     ];
 
     // customer
     #[PropertyTypeAttribute(CustomerTransfer::class)]
     public const string CUSTOMER = 'customer';
-    protected const string CUSTOMER_DATA_NAME = 'CUSTOMER';
-    protected const int CUSTOMER_DATA_INDEX = 0;
+    protected const int CUSTOMER_INDEX = 0;
 
     public ?CustomerTransfer $customer {
-        get => $this->getData(self::CUSTOMER_DATA_INDEX);
-        set => $this->setData(self::CUSTOMER_DATA_INDEX, $value);
+        get => $this->getData(self::CUSTOMER_INDEX);
+        set => $this->setData(self::CUSTOMER_INDEX, $value);
     }
 
     // merchants
     #[CollectionPropertyTypeAttribute(MerchantTransfer::class)]
     public const string MERCHANTS = 'merchants';
-    protected const string MERCHANTS_DATA_NAME = 'MERCHANTS';
-    protected const int MERCHANTS_DATA_INDEX = 1;
+    protected const int MERCHANTS_INDEX = 1;
 
     /** @var \ArrayObject<int,MerchantTransfer> */
     public ArrayObject $merchants {
-        get => $this->getData(self::MERCHANTS_DATA_INDEX);
-        set => $this->setData(self::MERCHANTS_DATA_INDEX, $value);
+        get => $this->getData(self::MERCHANTS_INDEX);
+        set => $this->setData(self::MERCHANTS_INDEX, $value);
     }
 }

--- a/examples/Generated/TransferGenerator/CredentialsTransfer.php
+++ b/examples/Generated/TransferGenerator/CredentialsTransfer.php
@@ -23,51 +23,47 @@ final class CredentialsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::CREATED_AT => self::CREATED_AT_DATA_NAME,
-        self::LOGIN => self::LOGIN_DATA_NAME,
-        self::TOKEN => self::TOKEN_DATA_NAME,
-        self::UPDATED_AT => self::UPDATED_AT_DATA_NAME,
+        self::CREATED_AT_INDEX => self::CREATED_AT,
+        self::LOGIN_INDEX => self::LOGIN,
+        self::TOKEN_INDEX => self::TOKEN,
+        self::UPDATED_AT_INDEX => self::UPDATED_AT,
     ];
 
     // createdAt
     #[DateTimePropertyTypeAttribute(DateTimeImmutable::class)]
     public const string CREATED_AT = 'createdAt';
-    protected const string CREATED_AT_DATA_NAME = 'CREATED_AT';
-    protected const int CREATED_AT_DATA_INDEX = 0;
+    protected const int CREATED_AT_INDEX = 0;
 
     public protected(set) DateTimeImmutable $createdAt {
-        get => $this->getData(self::CREATED_AT_DATA_INDEX);
-        set => $this->setData(self::CREATED_AT_DATA_INDEX, $value);
+        get => $this->getData(self::CREATED_AT_INDEX);
+        set => $this->setData(self::CREATED_AT_INDEX, $value);
     }
 
     // login
     public const string LOGIN = 'login';
-    protected const string LOGIN_DATA_NAME = 'LOGIN';
-    protected const int LOGIN_DATA_INDEX = 1;
+    protected const int LOGIN_INDEX = 1;
 
     public protected(set) string $login {
-        get => $this->getData(self::LOGIN_DATA_INDEX);
-        set => $this->setData(self::LOGIN_DATA_INDEX, $value);
+        get => $this->getData(self::LOGIN_INDEX);
+        set => $this->setData(self::LOGIN_INDEX, $value);
     }
 
     // token
     public const string TOKEN = 'token';
-    protected const string TOKEN_DATA_NAME = 'TOKEN';
-    protected const int TOKEN_DATA_INDEX = 2;
+    protected const int TOKEN_INDEX = 2;
 
     public protected(set) string $token {
-        get => $this->getData(self::TOKEN_DATA_INDEX);
-        set => $this->setData(self::TOKEN_DATA_INDEX, $value);
+        get => $this->getData(self::TOKEN_INDEX);
+        set => $this->setData(self::TOKEN_INDEX, $value);
     }
 
     // updatedAt
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string UPDATED_AT = 'updatedAt';
-    protected const string UPDATED_AT_DATA_NAME = 'UPDATED_AT';
-    protected const int UPDATED_AT_DATA_INDEX = 3;
+    protected const int UPDATED_AT_INDEX = 3;
 
     public DateTime $updatedAt {
-        get => $this->getData(self::UPDATED_AT_DATA_INDEX);
-        set => $this->setData(self::UPDATED_AT_DATA_INDEX, $value);
+        get => $this->getData(self::UPDATED_AT_INDEX);
+        set => $this->setData(self::UPDATED_AT_INDEX, $value);
     }
 }

--- a/examples/Generated/TransferGenerator/CustomerTransfer.php
+++ b/examples/Generated/TransferGenerator/CustomerTransfer.php
@@ -20,27 +20,25 @@ final class CustomerTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::FIRST_NAME => self::FIRST_NAME_DATA_NAME,
-        self::LAST_NAME => self::LAST_NAME_DATA_NAME,
+        self::FIRST_NAME_INDEX => self::FIRST_NAME,
+        self::LAST_NAME_INDEX => self::LAST_NAME,
     ];
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const string FIRST_NAME_DATA_NAME = 'FIRST_NAME';
-    protected const int FIRST_NAME_DATA_INDEX = 0;
+    protected const int FIRST_NAME_INDEX = 0;
 
     public ?string $firstName {
-        get => $this->getData(self::FIRST_NAME_DATA_INDEX);
-        set => $this->setData(self::FIRST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FIRST_NAME_INDEX);
+        set => $this->setData(self::FIRST_NAME_INDEX, $value);
     }
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const string LAST_NAME_DATA_NAME = 'LAST_NAME';
-    protected const int LAST_NAME_DATA_INDEX = 1;
+    protected const int LAST_NAME_INDEX = 1;
 
     public ?string $lastName {
-        get => $this->getData(self::LAST_NAME_DATA_INDEX);
-        set => $this->setData(self::LAST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::LAST_NAME_INDEX);
+        set => $this->setData(self::LAST_NAME_INDEX, $value);
     }
 }

--- a/examples/Generated/TransferGenerator/MerchantTransfer.php
+++ b/examples/Generated/TransferGenerator/MerchantTransfer.php
@@ -22,39 +22,36 @@ final class MerchantTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::COUNTRY => self::COUNTRY_DATA_NAME,
-        self::IS_ACTIVE => self::IS_ACTIVE_DATA_NAME,
-        self::MERCHANT_REFERENCE => self::MERCHANT_REFERENCE_DATA_NAME,
+        self::COUNTRY_INDEX => self::COUNTRY,
+        self::IS_ACTIVE_INDEX => self::IS_ACTIVE,
+        self::MERCHANT_REFERENCE_INDEX => self::MERCHANT_REFERENCE,
     ];
 
     // country
     #[EnumPropertyTypeAttribute(CountryEnum::class)]
     public const string COUNTRY = 'country';
-    protected const string COUNTRY_DATA_NAME = 'COUNTRY';
-    protected const int COUNTRY_DATA_INDEX = 0;
+    protected const int COUNTRY_INDEX = 0;
 
     public CountryEnum $country {
-        get => $this->getData(self::COUNTRY_DATA_INDEX);
-        set => $this->setData(self::COUNTRY_DATA_INDEX, $value);
+        get => $this->getData(self::COUNTRY_INDEX);
+        set => $this->setData(self::COUNTRY_INDEX, $value);
     }
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const string IS_ACTIVE_DATA_NAME = 'IS_ACTIVE';
-    protected const int IS_ACTIVE_DATA_INDEX = 1;
+    protected const int IS_ACTIVE_INDEX = 1;
 
     public bool $isActive {
-        get => $this->getData(self::IS_ACTIVE_DATA_INDEX);
-        set => $this->setData(self::IS_ACTIVE_DATA_INDEX, $value);
+        get => $this->getData(self::IS_ACTIVE_INDEX);
+        set => $this->setData(self::IS_ACTIVE_INDEX, $value);
     }
 
     // merchantReference
     public const string MERCHANT_REFERENCE = 'merchantReference';
-    protected const string MERCHANT_REFERENCE_DATA_NAME = 'MERCHANT_REFERENCE';
-    protected const int MERCHANT_REFERENCE_DATA_INDEX = 2;
+    protected const int MERCHANT_REFERENCE_INDEX = 2;
 
     public string $merchantReference {
-        get => $this->getData(self::MERCHANT_REFERENCE_DATA_INDEX);
-        set => $this->setData(self::MERCHANT_REFERENCE_DATA_INDEX, $value);
+        get => $this->getData(self::MERCHANT_REFERENCE_INDEX);
+        set => $this->setData(self::MERCHANT_REFERENCE_INDEX, $value);
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,16 +18,43 @@
     <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
-    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
-    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
-    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+
     <rule ref="SlevomatCodingStandard.Functions.NamedArgumentSpacing"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>
     <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
+
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+
+    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+
+    <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireSingleLineCondition"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
 
     <file>bin</file>
     <file>examples</file>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,3 +23,4 @@ parameters:
 rules:
    - PHPStan\Rules\DisallowedConstructs\DisallowedBacktickRule
    - PHPStan\Rules\StrictCalls\StrictFunctionCallsRule
+   - PHPStan\Rules\Classes\RequireParentConstructCallRule

--- a/src/Command/DefinitionGeneratorCommand.php
+++ b/src/Command/DefinitionGeneratorCommand.php
@@ -22,17 +22,10 @@ use Throwable;
     name: 'picamator:definition:generate',
     description: 'Generates Transfer Object definition files from a JSON blueprint.',
     aliases: ['p:d:g'],
-    hidden: false
-)]
-class DefinitionGeneratorCommand extends Command
-{
-    use InputNormalizerTrait;
-
-    /**
-     * phpcs:disable Generic.Files.LineLength
-     */
-    private const string HELP = <<<'HELP'
-This command generates Transfer Object definition files based on a JSON blueprint.
+    hidden: false,
+    // phpcs:disable Generic.Files.LineLength
+    help: <<<HELP
+The <info>%command.name%</info> command generates Transfer Object definition files based on a JSON blueprint.
 
 <options=bold>Interactive prompt options:</>
   - Specify the directory path where the definition files will be saved.
@@ -42,7 +35,11 @@ This command generates Transfer Object definition files based on a JSON blueprin
 <options=bold>Documentation:</>
 For more details, please visit "<href=https://github.com/picamator/transfer-object/wiki/Console-Commands#definition-generate>project's Wiki</>".
 
-HELP;
+HELP
+)]
+class DefinitionGeneratorCommand extends Command
+{
+    use InputNormalizerTrait;
 
     private const string QUESTION_DEFINITION_PATH = 'Definition directory path: ';
     private const string QUESTION_CLASS_NAME = 'Transfer Object class name: ';
@@ -57,11 +54,6 @@ HELP;
         private readonly DefinitionGeneratorFacadeInterface $generatorFacade = new DefinitionGeneratorFacade(),
     ) {
         parent::__construct($name);
-    }
-
-    protected function configure(): void
-    {
-        $this->setHelp(help: self::HELP);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/TransferGeneratorBulkCommand.php
+++ b/src/Command/TransferGeneratorBulkCommand.php
@@ -20,17 +20,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'picamator:transfer:generate:bulk',
     description: 'Generates Transfer Objects based on multiple configurations and their definition files.',
     aliases: ['p:t:g:b'],
-    hidden: false
-)]
-class TransferGeneratorBulkCommand extends Command
-{
-    use InputNormalizerTrait;
-
-    /**
-     * phpcs:disable Generic.Files.LineLength
-     */
-    private const string HELP = <<<'HELP'
-This command generates Transfer Objects from definition files specified by multiple configuration files listed in a TXT file..
+    hidden: false,
+    // phpcs:disable Generic.Files.LineLength
+    help: <<<HELP
+The <info>%command.name%</info> command generates Transfer Objects from definition files specified by multiple configuration files listed in a TXT file..
 
 <options=bold>The configuration list specifies:</>
   -  Each line contains the path to a configuration file in YML format.
@@ -38,7 +31,11 @@ This command generates Transfer Objects from definition files specified by multi
 <options=bold>Documentation:</>
 For more details, please visit "<href=https://github.com/picamator/transfer-object/wiki/Console-Commands#transfer-generate-bulk>project's Wiki</>".
 
-HELP;
+HELP
+)]
+class TransferGeneratorBulkCommand extends Command
+{
+    use InputNormalizerTrait;
 
     private const string OPTION_NAME_BULK = 'bulk';
     private const string OPTION_SHORTCUT_BULK = 'b';
@@ -64,8 +61,6 @@ MESSAGE;
 
     protected function configure(): void
     {
-        $this->setHelp(help: self::HELP);
-
         $this->addOption(
             name: self::OPTION_NAME_BULK,
             shortcut: self::OPTION_SHORTCUT_BULK,

--- a/src/Command/TransferGeneratorCommand.php
+++ b/src/Command/TransferGeneratorCommand.php
@@ -19,17 +19,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'picamator:transfer:generate',
     description: 'Generates Transfer Objects from definition files specified by configuration.',
     aliases: ['p:t:g'],
-    hidden: false
-)]
-class TransferGeneratorCommand extends Command
-{
-    use InputNormalizerTrait;
-
-    /**
-     * phpcs:disable Generic.Files.LineLength
-     */
-    private const string HELP = <<<'HELP'
-This command generates Transfer Objects based on configuration file in YML format.
+    hidden: false,
+    // phpcs:disable Generic.Files.LineLength
+    help: <<<HELP
+The <info>%command.name%</info> command generates Transfer Objects based on configuration file in YML format.
 
 <options=bold>The configuration specifies:</>
   - The directory containing the definition files.
@@ -46,7 +39,11 @@ The command supports the first verbosity level to display additional details abo
 <options=bold>Documentation:</>
 For more details, please visit "<href=https://github.com/picamator/transfer-object/wiki/Console-Commands#transfer-generate>project's Wiki</>".
 
-HELP;
+HELP
+)]
+class TransferGeneratorCommand extends Command
+{
+    use InputNormalizerTrait;
 
     private const string OPTION_NAME_CONFIGURATION = 'configuration';
     private const string OPTION_SHORTCUT_CONFIGURATION = 'c';
@@ -75,8 +72,6 @@ MESSAGE;
 
     protected function configure(): void
     {
-        $this->setHelp(help: self::HELP);
-
         $this->addOption(
             name: self::OPTION_NAME_CONFIGURATION,
             shortcut: self::OPTION_SHORTCUT_CONFIGURATION,

--- a/src/Dependency/DependencyContainer.php
+++ b/src/Dependency/DependencyContainer.php
@@ -30,7 +30,6 @@ class DependencyContainer implements ContainerInterface
     protected static array $container = [];
 
     /**
-     *
      * @uses static::createFinder()
      * @uses static::createFileSystem()
      * @uses static::createYmlParser()

--- a/src/Generated/ConfigContentTransfer.php
+++ b/src/Generated/ConfigContentTransfer.php
@@ -20,49 +20,45 @@ final class ConfigContentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::DEFINITION_PATH => self::DEFINITION_PATH_DATA_NAME,
-        self::RELATIVE_DEFINITION_PATH => self::RELATIVE_DEFINITION_PATH_DATA_NAME,
-        self::TRANSFER_NAMESPACE => self::TRANSFER_NAMESPACE_DATA_NAME,
-        self::TRANSFER_PATH => self::TRANSFER_PATH_DATA_NAME,
+        self::DEFINITION_PATH_INDEX => self::DEFINITION_PATH,
+        self::RELATIVE_DEFINITION_PATH_INDEX => self::RELATIVE_DEFINITION_PATH,
+        self::TRANSFER_NAMESPACE_INDEX => self::TRANSFER_NAMESPACE,
+        self::TRANSFER_PATH_INDEX => self::TRANSFER_PATH,
     ];
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const string DEFINITION_PATH_DATA_NAME = 'DEFINITION_PATH';
-    protected const int DEFINITION_PATH_DATA_INDEX = 0;
+    protected const int DEFINITION_PATH_INDEX = 0;
 
     public string $definitionPath {
-        get => $this->getData(self::DEFINITION_PATH_DATA_INDEX);
-        set => $this->setData(self::DEFINITION_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::DEFINITION_PATH_INDEX);
+        set => $this->setData(self::DEFINITION_PATH_INDEX, $value);
     }
 
     // relativeDefinitionPath
     public const string RELATIVE_DEFINITION_PATH = 'relativeDefinitionPath';
-    protected const string RELATIVE_DEFINITION_PATH_DATA_NAME = 'RELATIVE_DEFINITION_PATH';
-    protected const int RELATIVE_DEFINITION_PATH_DATA_INDEX = 1;
+    protected const int RELATIVE_DEFINITION_PATH_INDEX = 1;
 
     public string $relativeDefinitionPath {
-        get => $this->getData(self::RELATIVE_DEFINITION_PATH_DATA_INDEX);
-        set => $this->setData(self::RELATIVE_DEFINITION_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::RELATIVE_DEFINITION_PATH_INDEX);
+        set => $this->setData(self::RELATIVE_DEFINITION_PATH_INDEX, $value);
     }
 
     // transferNamespace
     public const string TRANSFER_NAMESPACE = 'transferNamespace';
-    protected const string TRANSFER_NAMESPACE_DATA_NAME = 'TRANSFER_NAMESPACE';
-    protected const int TRANSFER_NAMESPACE_DATA_INDEX = 2;
+    protected const int TRANSFER_NAMESPACE_INDEX = 2;
 
     public string $transferNamespace {
-        get => $this->getData(self::TRANSFER_NAMESPACE_DATA_INDEX);
-        set => $this->setData(self::TRANSFER_NAMESPACE_DATA_INDEX, $value);
+        get => $this->getData(self::TRANSFER_NAMESPACE_INDEX);
+        set => $this->setData(self::TRANSFER_NAMESPACE_INDEX, $value);
     }
 
     // transferPath
     public const string TRANSFER_PATH = 'transferPath';
-    protected const string TRANSFER_PATH_DATA_NAME = 'TRANSFER_PATH';
-    protected const int TRANSFER_PATH_DATA_INDEX = 3;
+    protected const int TRANSFER_PATH_INDEX = 3;
 
     public string $transferPath {
-        get => $this->getData(self::TRANSFER_PATH_DATA_INDEX);
-        set => $this->setData(self::TRANSFER_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::TRANSFER_PATH_INDEX);
+        set => $this->setData(self::TRANSFER_PATH_INDEX, $value);
     }
 }

--- a/src/Generated/ConfigTransfer.php
+++ b/src/Generated/ConfigTransfer.php
@@ -21,29 +21,27 @@ final class ConfigTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::VALIDATOR => self::VALIDATOR_DATA_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::VALIDATOR_INDEX => self::VALIDATOR,
     ];
 
     // content
     #[PropertyTypeAttribute(ConfigContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 0;
+    protected const int CONTENT_INDEX = 0;
 
     public ConfigContentTransfer $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const string VALIDATOR_DATA_NAME = 'VALIDATOR';
-    protected const int VALIDATOR_DATA_INDEX = 1;
+    protected const int VALIDATOR_INDEX = 1;
 
     public ValidatorTransfer $validator {
-        get => $this->getData(self::VALIDATOR_DATA_INDEX);
-        set => $this->setData(self::VALIDATOR_DATA_INDEX, $value);
+        get => $this->getData(self::VALIDATOR_INDEX);
+        set => $this->setData(self::VALIDATOR_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionBuilderTransfer.php
+++ b/src/Generated/DefinitionBuilderTransfer.php
@@ -23,30 +23,28 @@ final class DefinitionBuilderTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::DEFINITION_CONTENT => self::DEFINITION_CONTENT_DATA_NAME,
-        self::GENERATOR_CONTENTS => self::GENERATOR_CONTENTS_DATA_NAME,
+        self::DEFINITION_CONTENT_INDEX => self::DEFINITION_CONTENT,
+        self::GENERATOR_CONTENTS_INDEX => self::GENERATOR_CONTENTS,
     ];
 
     // definitionContent
     #[PropertyTypeAttribute(DefinitionContentTransfer::class)]
     public const string DEFINITION_CONTENT = 'definitionContent';
-    protected const string DEFINITION_CONTENT_DATA_NAME = 'DEFINITION_CONTENT';
-    protected const int DEFINITION_CONTENT_DATA_INDEX = 0;
+    protected const int DEFINITION_CONTENT_INDEX = 0;
 
     public DefinitionContentTransfer $definitionContent {
-        get => $this->getData(self::DEFINITION_CONTENT_DATA_INDEX);
-        set => $this->setData(self::DEFINITION_CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::DEFINITION_CONTENT_INDEX);
+        set => $this->setData(self::DEFINITION_CONTENT_INDEX, $value);
     }
 
     // generatorContents
     #[CollectionPropertyTypeAttribute(DefinitionGeneratorContentTransfer::class)]
     public const string GENERATOR_CONTENTS = 'generatorContents';
-    protected const string GENERATOR_CONTENTS_DATA_NAME = 'GENERATOR_CONTENTS';
-    protected const int GENERATOR_CONTENTS_DATA_INDEX = 1;
+    protected const int GENERATOR_CONTENTS_INDEX = 1;
 
     /** @var \ArrayObject<int,DefinitionGeneratorContentTransfer> */
     public ArrayObject $generatorContents {
-        get => $this->getData(self::GENERATOR_CONTENTS_DATA_INDEX);
-        set => $this->setData(self::GENERATOR_CONTENTS_DATA_INDEX, $value);
+        get => $this->getData(self::GENERATOR_CONTENTS_INDEX);
+        set => $this->setData(self::GENERATOR_CONTENTS_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionContentTransfer.php
+++ b/src/Generated/DefinitionContentTransfer.php
@@ -22,29 +22,27 @@ final class DefinitionContentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CLASS_NAME => self::CLASS_NAME_DATA_NAME,
-        self::PROPERTIES => self::PROPERTIES_DATA_NAME,
+        self::CLASS_NAME_INDEX => self::CLASS_NAME,
+        self::PROPERTIES_INDEX => self::PROPERTIES,
     ];
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const string CLASS_NAME_DATA_NAME = 'CLASS_NAME';
-    protected const int CLASS_NAME_DATA_INDEX = 0;
+    protected const int CLASS_NAME_INDEX = 0;
 
     public string $className {
-        get => $this->getData(self::CLASS_NAME_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAME_INDEX);
+        set => $this->setData(self::CLASS_NAME_INDEX, $value);
     }
 
     // properties
     #[CollectionPropertyTypeAttribute(DefinitionPropertyTransfer::class)]
     public const string PROPERTIES = 'properties';
-    protected const string PROPERTIES_DATA_NAME = 'PROPERTIES';
-    protected const int PROPERTIES_DATA_INDEX = 1;
+    protected const int PROPERTIES_INDEX = 1;
 
     /** @var \ArrayObject<int,DefinitionPropertyTransfer> */
     public ArrayObject $properties {
-        get => $this->getData(self::PROPERTIES_DATA_INDEX);
-        set => $this->setData(self::PROPERTIES_DATA_INDEX, $value);
+        get => $this->getData(self::PROPERTIES_INDEX);
+        set => $this->setData(self::PROPERTIES_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionEmbeddedTypeTransfer.php
+++ b/src/Generated/DefinitionEmbeddedTypeTransfer.php
@@ -21,28 +21,26 @@ final class DefinitionEmbeddedTypeTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::NAME => self::NAME_DATA_NAME,
-        self::NAMESPACE => self::NAMESPACE_DATA_NAME,
+        self::NAME_INDEX => self::NAME,
+        self::NAMESPACE_INDEX => self::NAMESPACE,
     ];
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 0;
+    protected const int NAME_INDEX = 0;
 
     public string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 
     // namespace
     #[PropertyTypeAttribute(DefinitionNamespaceTransfer::class)]
     public const string NAMESPACE = 'namespace';
-    protected const string NAMESPACE_DATA_NAME = 'NAMESPACE';
-    protected const int NAMESPACE_DATA_INDEX = 1;
+    protected const int NAMESPACE_INDEX = 1;
 
     public ?DefinitionNamespaceTransfer $namespace {
-        get => $this->getData(self::NAMESPACE_DATA_INDEX);
-        set => $this->setData(self::NAMESPACE_DATA_INDEX, $value);
+        get => $this->getData(self::NAMESPACE_INDEX);
+        set => $this->setData(self::NAMESPACE_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionFilesystemTransfer.php
+++ b/src/Generated/DefinitionFilesystemTransfer.php
@@ -20,38 +20,35 @@ final class DefinitionFilesystemTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::DEFINITION_PATH => self::DEFINITION_PATH_DATA_NAME,
-        self::FILE_NAME => self::FILE_NAME_DATA_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::DEFINITION_PATH_INDEX => self::DEFINITION_PATH,
+        self::FILE_NAME_INDEX => self::FILE_NAME,
     ];
 
     // content
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 0;
+    protected const int CONTENT_INDEX = 0;
 
     public string $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const string DEFINITION_PATH_DATA_NAME = 'DEFINITION_PATH';
-    protected const int DEFINITION_PATH_DATA_INDEX = 1;
+    protected const int DEFINITION_PATH_INDEX = 1;
 
     public string $definitionPath {
-        get => $this->getData(self::DEFINITION_PATH_DATA_INDEX);
-        set => $this->setData(self::DEFINITION_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::DEFINITION_PATH_INDEX);
+        set => $this->setData(self::DEFINITION_PATH_INDEX, $value);
     }
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const string FILE_NAME_DATA_NAME = 'FILE_NAME';
-    protected const int FILE_NAME_DATA_INDEX = 2;
+    protected const int FILE_NAME_INDEX = 2;
 
     public string $fileName {
-        get => $this->getData(self::FILE_NAME_DATA_INDEX);
-        set => $this->setData(self::FILE_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FILE_NAME_INDEX);
+        set => $this->setData(self::FILE_NAME_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionGeneratorContentTransfer.php
+++ b/src/Generated/DefinitionGeneratorContentTransfer.php
@@ -21,29 +21,27 @@ final class DefinitionGeneratorContentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CLASS_NAME => self::CLASS_NAME_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
+        self::CLASS_NAME_INDEX => self::CLASS_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
     ];
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const string CLASS_NAME_DATA_NAME = 'CLASS_NAME';
-    protected const int CLASS_NAME_DATA_INDEX = 0;
+    protected const int CLASS_NAME_INDEX = 0;
 
     public string $className {
-        get => $this->getData(self::CLASS_NAME_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAME_INDEX);
+        set => $this->setData(self::CLASS_NAME_INDEX, $value);
     }
 
     // content
     #[ArrayPropertyTypeAttribute]
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     /** @var array<int|string,mixed> */
     public array $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionGeneratorTransfer.php
+++ b/src/Generated/DefinitionGeneratorTransfer.php
@@ -21,28 +21,26 @@ final class DefinitionGeneratorTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::DEFINITION_PATH => self::DEFINITION_PATH_DATA_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::DEFINITION_PATH_INDEX => self::DEFINITION_PATH,
     ];
 
     // content
     #[PropertyTypeAttribute(DefinitionGeneratorContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 0;
+    protected const int CONTENT_INDEX = 0;
 
     public DefinitionGeneratorContentTransfer $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const string DEFINITION_PATH_DATA_NAME = 'DEFINITION_PATH';
-    protected const int DEFINITION_PATH_DATA_INDEX = 1;
+    protected const int DEFINITION_PATH_INDEX = 1;
 
     public string $definitionPath {
-        get => $this->getData(self::DEFINITION_PATH_DATA_INDEX);
-        set => $this->setData(self::DEFINITION_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::DEFINITION_PATH_INDEX);
+        set => $this->setData(self::DEFINITION_PATH_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionNamespaceTransfer.php
+++ b/src/Generated/DefinitionNamespaceTransfer.php
@@ -20,49 +20,45 @@ final class DefinitionNamespaceTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::ALIAS => self::ALIAS_DATA_NAME,
-        self::BASE_NAME => self::BASE_NAME_DATA_NAME,
-        self::FULL_NAME => self::FULL_NAME_DATA_NAME,
-        self::WITHOUT_ALIAS => self::WITHOUT_ALIAS_DATA_NAME,
+        self::ALIAS_INDEX => self::ALIAS,
+        self::BASE_NAME_INDEX => self::BASE_NAME,
+        self::FULL_NAME_INDEX => self::FULL_NAME,
+        self::WITHOUT_ALIAS_INDEX => self::WITHOUT_ALIAS,
     ];
 
     // alias
     public const string ALIAS = 'alias';
-    protected const string ALIAS_DATA_NAME = 'ALIAS';
-    protected const int ALIAS_DATA_INDEX = 0;
+    protected const int ALIAS_INDEX = 0;
 
     public ?string $alias {
-        get => $this->getData(self::ALIAS_DATA_INDEX);
-        set => $this->setData(self::ALIAS_DATA_INDEX, $value);
+        get => $this->getData(self::ALIAS_INDEX);
+        set => $this->setData(self::ALIAS_INDEX, $value);
     }
 
     // baseName
     public const string BASE_NAME = 'baseName';
-    protected const string BASE_NAME_DATA_NAME = 'BASE_NAME';
-    protected const int BASE_NAME_DATA_INDEX = 1;
+    protected const int BASE_NAME_INDEX = 1;
 
     public string $baseName {
-        get => $this->getData(self::BASE_NAME_DATA_INDEX);
-        set => $this->setData(self::BASE_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::BASE_NAME_INDEX);
+        set => $this->setData(self::BASE_NAME_INDEX, $value);
     }
 
     // fullName
     public const string FULL_NAME = 'fullName';
-    protected const string FULL_NAME_DATA_NAME = 'FULL_NAME';
-    protected const int FULL_NAME_DATA_INDEX = 2;
+    protected const int FULL_NAME_INDEX = 2;
 
     public string $fullName {
-        get => $this->getData(self::FULL_NAME_DATA_INDEX);
-        set => $this->setData(self::FULL_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FULL_NAME_INDEX);
+        set => $this->setData(self::FULL_NAME_INDEX, $value);
     }
 
     // withoutAlias
     public const string WITHOUT_ALIAS = 'withoutAlias';
-    protected const string WITHOUT_ALIAS_DATA_NAME = 'WITHOUT_ALIAS';
-    protected const int WITHOUT_ALIAS_DATA_INDEX = 3;
+    protected const int WITHOUT_ALIAS_INDEX = 3;
 
     public string $withoutAlias {
-        get => $this->getData(self::WITHOUT_ALIAS_DATA_INDEX);
-        set => $this->setData(self::WITHOUT_ALIAS_DATA_INDEX, $value);
+        get => $this->getData(self::WITHOUT_ALIAS_INDEX);
+        set => $this->setData(self::WITHOUT_ALIAS_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionPropertyTransfer.php
+++ b/src/Generated/DefinitionPropertyTransfer.php
@@ -23,110 +23,101 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 9;
 
     protected const array META_DATA = [
-        self::BUILD_IN_TYPE => self::BUILD_IN_TYPE_DATA_NAME,
-        self::COLLECTION_TYPE => self::COLLECTION_TYPE_DATA_NAME,
-        self::DATE_TIME_TYPE => self::DATE_TIME_TYPE_DATA_NAME,
-        self::ENUM_TYPE => self::ENUM_TYPE_DATA_NAME,
-        self::IS_NULLABLE => self::IS_NULLABLE_DATA_NAME,
-        self::IS_PROTECTED => self::IS_PROTECTED_DATA_NAME,
-        self::NUMBER_TYPE => self::NUMBER_TYPE_DATA_NAME,
-        self::PROPERTY_NAME => self::PROPERTY_NAME_DATA_NAME,
-        self::TRANSFER_TYPE => self::TRANSFER_TYPE_DATA_NAME,
+        self::BUILD_IN_TYPE_INDEX => self::BUILD_IN_TYPE,
+        self::COLLECTION_TYPE_INDEX => self::COLLECTION_TYPE,
+        self::DATE_TIME_TYPE_INDEX => self::DATE_TIME_TYPE,
+        self::ENUM_TYPE_INDEX => self::ENUM_TYPE,
+        self::IS_NULLABLE_INDEX => self::IS_NULLABLE,
+        self::IS_PROTECTED_INDEX => self::IS_PROTECTED,
+        self::NUMBER_TYPE_INDEX => self::NUMBER_TYPE,
+        self::PROPERTY_NAME_INDEX => self::PROPERTY_NAME,
+        self::TRANSFER_TYPE_INDEX => self::TRANSFER_TYPE,
     ];
 
     // buildInType
     #[EnumPropertyTypeAttribute(BuildInTypeEnum::class)]
     public const string BUILD_IN_TYPE = 'buildInType';
-    protected const string BUILD_IN_TYPE_DATA_NAME = 'BUILD_IN_TYPE';
-    protected const int BUILD_IN_TYPE_DATA_INDEX = 0;
+    protected const int BUILD_IN_TYPE_INDEX = 0;
 
     public ?BuildInTypeEnum $buildInType {
-        get => $this->getData(self::BUILD_IN_TYPE_DATA_INDEX);
-        set => $this->setData(self::BUILD_IN_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::BUILD_IN_TYPE_INDEX);
+        set => $this->setData(self::BUILD_IN_TYPE_INDEX, $value);
     }
 
     // collectionType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string COLLECTION_TYPE = 'collectionType';
-    protected const string COLLECTION_TYPE_DATA_NAME = 'COLLECTION_TYPE';
-    protected const int COLLECTION_TYPE_DATA_INDEX = 1;
+    protected const int COLLECTION_TYPE_INDEX = 1;
 
     public ?DefinitionEmbeddedTypeTransfer $collectionType {
-        get => $this->getData(self::COLLECTION_TYPE_DATA_INDEX);
-        set => $this->setData(self::COLLECTION_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::COLLECTION_TYPE_INDEX);
+        set => $this->setData(self::COLLECTION_TYPE_INDEX, $value);
     }
 
     // dateTimeType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string DATE_TIME_TYPE = 'dateTimeType';
-    protected const string DATE_TIME_TYPE_DATA_NAME = 'DATE_TIME_TYPE';
-    protected const int DATE_TIME_TYPE_DATA_INDEX = 2;
+    protected const int DATE_TIME_TYPE_INDEX = 2;
 
     public ?DefinitionEmbeddedTypeTransfer $dateTimeType {
-        get => $this->getData(self::DATE_TIME_TYPE_DATA_INDEX);
-        set => $this->setData(self::DATE_TIME_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::DATE_TIME_TYPE_INDEX);
+        set => $this->setData(self::DATE_TIME_TYPE_INDEX, $value);
     }
 
     // enumType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string ENUM_TYPE = 'enumType';
-    protected const string ENUM_TYPE_DATA_NAME = 'ENUM_TYPE';
-    protected const int ENUM_TYPE_DATA_INDEX = 3;
+    protected const int ENUM_TYPE_INDEX = 3;
 
     public ?DefinitionEmbeddedTypeTransfer $enumType {
-        get => $this->getData(self::ENUM_TYPE_DATA_INDEX);
-        set => $this->setData(self::ENUM_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::ENUM_TYPE_INDEX);
+        set => $this->setData(self::ENUM_TYPE_INDEX, $value);
     }
 
     // isNullable
     public const string IS_NULLABLE = 'isNullable';
-    protected const string IS_NULLABLE_DATA_NAME = 'IS_NULLABLE';
-    protected const int IS_NULLABLE_DATA_INDEX = 4;
+    protected const int IS_NULLABLE_INDEX = 4;
 
     public bool $isNullable {
-        get => $this->getData(self::IS_NULLABLE_DATA_INDEX);
-        set => $this->setData(self::IS_NULLABLE_DATA_INDEX, $value);
+        get => $this->getData(self::IS_NULLABLE_INDEX);
+        set => $this->setData(self::IS_NULLABLE_INDEX, $value);
     }
 
     // isProtected
     public const string IS_PROTECTED = 'isProtected';
-    protected const string IS_PROTECTED_DATA_NAME = 'IS_PROTECTED';
-    protected const int IS_PROTECTED_DATA_INDEX = 5;
+    protected const int IS_PROTECTED_INDEX = 5;
 
     public bool $isProtected {
-        get => $this->getData(self::IS_PROTECTED_DATA_INDEX);
-        set => $this->setData(self::IS_PROTECTED_DATA_INDEX, $value);
+        get => $this->getData(self::IS_PROTECTED_INDEX);
+        set => $this->setData(self::IS_PROTECTED_INDEX, $value);
     }
 
     // numberType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string NUMBER_TYPE = 'numberType';
-    protected const string NUMBER_TYPE_DATA_NAME = 'NUMBER_TYPE';
-    protected const int NUMBER_TYPE_DATA_INDEX = 6;
+    protected const int NUMBER_TYPE_INDEX = 6;
 
     public ?DefinitionEmbeddedTypeTransfer $numberType {
-        get => $this->getData(self::NUMBER_TYPE_DATA_INDEX);
-        set => $this->setData(self::NUMBER_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::NUMBER_TYPE_INDEX);
+        set => $this->setData(self::NUMBER_TYPE_INDEX, $value);
     }
 
     // propertyName
     public const string PROPERTY_NAME = 'propertyName';
-    protected const string PROPERTY_NAME_DATA_NAME = 'PROPERTY_NAME';
-    protected const int PROPERTY_NAME_DATA_INDEX = 7;
+    protected const int PROPERTY_NAME_INDEX = 7;
 
     public string $propertyName {
-        get => $this->getData(self::PROPERTY_NAME_DATA_INDEX);
-        set => $this->setData(self::PROPERTY_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::PROPERTY_NAME_INDEX);
+        set => $this->setData(self::PROPERTY_NAME_INDEX, $value);
     }
 
     // transferType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string TRANSFER_TYPE = 'transferType';
-    protected const string TRANSFER_TYPE_DATA_NAME = 'TRANSFER_TYPE';
-    protected const int TRANSFER_TYPE_DATA_INDEX = 8;
+    protected const int TRANSFER_TYPE_INDEX = 8;
 
     public ?DefinitionEmbeddedTypeTransfer $transferType {
-        get => $this->getData(self::TRANSFER_TYPE_DATA_INDEX);
-        set => $this->setData(self::TRANSFER_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TRANSFER_TYPE_INDEX);
+        set => $this->setData(self::TRANSFER_TYPE_INDEX, $value);
     }
 }

--- a/src/Generated/DefinitionTransfer.php
+++ b/src/Generated/DefinitionTransfer.php
@@ -21,40 +21,37 @@ final class DefinitionTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::FILE_NAME => self::FILE_NAME_DATA_NAME,
-        self::VALIDATOR => self::VALIDATOR_DATA_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::FILE_NAME_INDEX => self::FILE_NAME,
+        self::VALIDATOR_INDEX => self::VALIDATOR,
     ];
 
     // content
     #[PropertyTypeAttribute(DefinitionContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 0;
+    protected const int CONTENT_INDEX = 0;
 
     public DefinitionContentTransfer $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const string FILE_NAME_DATA_NAME = 'FILE_NAME';
-    protected const int FILE_NAME_DATA_INDEX = 1;
+    protected const int FILE_NAME_INDEX = 1;
 
     public string $fileName {
-        get => $this->getData(self::FILE_NAME_DATA_INDEX);
-        set => $this->setData(self::FILE_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FILE_NAME_INDEX);
+        set => $this->setData(self::FILE_NAME_INDEX, $value);
     }
 
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const string VALIDATOR_DATA_NAME = 'VALIDATOR';
-    protected const int VALIDATOR_DATA_INDEX = 2;
+    protected const int VALIDATOR_INDEX = 2;
 
     public ValidatorTransfer $validator {
-        get => $this->getData(self::VALIDATOR_DATA_INDEX);
-        set => $this->setData(self::VALIDATOR_DATA_INDEX, $value);
+        get => $this->getData(self::VALIDATOR_INDEX);
+        set => $this->setData(self::VALIDATOR_INDEX, $value);
     }
 }

--- a/src/Generated/FileReaderProgressTransfer.php
+++ b/src/Generated/FileReaderProgressTransfer.php
@@ -20,38 +20,35 @@ final class FileReaderProgressTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::PROGRESS_BYTES => self::PROGRESS_BYTES_DATA_NAME,
-        self::TOTAL_BYTES => self::TOTAL_BYTES_DATA_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::PROGRESS_BYTES_INDEX => self::PROGRESS_BYTES,
+        self::TOTAL_BYTES_INDEX => self::TOTAL_BYTES,
     ];
 
     // content
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 0;
+    protected const int CONTENT_INDEX = 0;
 
     public string $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // progressBytes
     public const string PROGRESS_BYTES = 'progressBytes';
-    protected const string PROGRESS_BYTES_DATA_NAME = 'PROGRESS_BYTES';
-    protected const int PROGRESS_BYTES_DATA_INDEX = 1;
+    protected const int PROGRESS_BYTES_INDEX = 1;
 
     public int $progressBytes {
-        get => $this->getData(self::PROGRESS_BYTES_DATA_INDEX);
-        set => $this->setData(self::PROGRESS_BYTES_DATA_INDEX, $value);
+        get => $this->getData(self::PROGRESS_BYTES_INDEX);
+        set => $this->setData(self::PROGRESS_BYTES_INDEX, $value);
     }
 
     // totalBytes
     public const string TOTAL_BYTES = 'totalBytes';
-    protected const string TOTAL_BYTES_DATA_NAME = 'TOTAL_BYTES';
-    protected const int TOTAL_BYTES_DATA_INDEX = 2;
+    protected const int TOTAL_BYTES_INDEX = 2;
 
     public int $totalBytes {
-        get => $this->getData(self::TOTAL_BYTES_DATA_INDEX);
-        set => $this->setData(self::TOTAL_BYTES_DATA_INDEX, $value);
+        get => $this->getData(self::TOTAL_BYTES_INDEX);
+        set => $this->setData(self::TOTAL_BYTES_INDEX, $value);
     }
 }

--- a/src/Generated/TemplateTransfer.php
+++ b/src/Generated/TemplateTransfer.php
@@ -22,129 +22,119 @@ final class TemplateTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 10;
 
     protected const array META_DATA = [
-        self::ATTRIBUTES => self::ATTRIBUTES_DATA_NAME,
-        self::CLASS_NAME => self::CLASS_NAME_DATA_NAME,
-        self::CLASS_NAMESPACE => self::CLASS_NAMESPACE_DATA_NAME,
-        self::DEFINITION_PATH => self::DEFINITION_PATH_DATA_NAME,
-        self::DOCK_BLOCKS => self::DOCK_BLOCKS_DATA_NAME,
-        self::IMPORTS => self::IMPORTS_DATA_NAME,
-        self::META_CONSTANTS => self::META_CONSTANTS_DATA_NAME,
-        self::NULLABLES => self::NULLABLES_DATA_NAME,
-        self::PROPERTIES => self::PROPERTIES_DATA_NAME,
-        self::PROTECTS => self::PROTECTS_DATA_NAME,
+        self::ATTRIBUTES_INDEX => self::ATTRIBUTES,
+        self::CLASS_NAME_INDEX => self::CLASS_NAME,
+        self::CLASS_NAMESPACE_INDEX => self::CLASS_NAMESPACE,
+        self::DEFINITION_PATH_INDEX => self::DEFINITION_PATH,
+        self::DOCK_BLOCKS_INDEX => self::DOCK_BLOCKS,
+        self::IMPORTS_INDEX => self::IMPORTS,
+        self::META_CONSTANTS_INDEX => self::META_CONSTANTS,
+        self::NULLABLES_INDEX => self::NULLABLES,
+        self::PROPERTIES_INDEX => self::PROPERTIES,
+        self::PROTECTS_INDEX => self::PROTECTS,
     ];
 
     // attributes
     #[ArrayObjectPropertyTypeAttribute]
     public const string ATTRIBUTES = 'attributes';
-    protected const string ATTRIBUTES_DATA_NAME = 'ATTRIBUTES';
-    protected const int ATTRIBUTES_DATA_INDEX = 0;
+    protected const int ATTRIBUTES_INDEX = 0;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $attributes {
-        get => $this->getData(self::ATTRIBUTES_DATA_INDEX);
-        set => $this->setData(self::ATTRIBUTES_DATA_INDEX, $value);
+        get => $this->getData(self::ATTRIBUTES_INDEX);
+        set => $this->setData(self::ATTRIBUTES_INDEX, $value);
     }
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const string CLASS_NAME_DATA_NAME = 'CLASS_NAME';
-    protected const int CLASS_NAME_DATA_INDEX = 1;
+    protected const int CLASS_NAME_INDEX = 1;
 
     public string $className {
-        get => $this->getData(self::CLASS_NAME_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAME_INDEX);
+        set => $this->setData(self::CLASS_NAME_INDEX, $value);
     }
 
     // classNamespace
     public const string CLASS_NAMESPACE = 'classNamespace';
-    protected const string CLASS_NAMESPACE_DATA_NAME = 'CLASS_NAMESPACE';
-    protected const int CLASS_NAMESPACE_DATA_INDEX = 2;
+    protected const int CLASS_NAMESPACE_INDEX = 2;
 
     public string $classNamespace {
-        get => $this->getData(self::CLASS_NAMESPACE_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAMESPACE_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAMESPACE_INDEX);
+        set => $this->setData(self::CLASS_NAMESPACE_INDEX, $value);
     }
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const string DEFINITION_PATH_DATA_NAME = 'DEFINITION_PATH';
-    protected const int DEFINITION_PATH_DATA_INDEX = 3;
+    protected const int DEFINITION_PATH_INDEX = 3;
 
     public string $definitionPath {
-        get => $this->getData(self::DEFINITION_PATH_DATA_INDEX);
-        set => $this->setData(self::DEFINITION_PATH_DATA_INDEX, $value);
+        get => $this->getData(self::DEFINITION_PATH_INDEX);
+        set => $this->setData(self::DEFINITION_PATH_INDEX, $value);
     }
 
     // dockBlocks
     #[ArrayObjectPropertyTypeAttribute]
     public const string DOCK_BLOCKS = 'dockBlocks';
-    protected const string DOCK_BLOCKS_DATA_NAME = 'DOCK_BLOCKS';
-    protected const int DOCK_BLOCKS_DATA_INDEX = 4;
+    protected const int DOCK_BLOCKS_INDEX = 4;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $dockBlocks {
-        get => $this->getData(self::DOCK_BLOCKS_DATA_INDEX);
-        set => $this->setData(self::DOCK_BLOCKS_DATA_INDEX, $value);
+        get => $this->getData(self::DOCK_BLOCKS_INDEX);
+        set => $this->setData(self::DOCK_BLOCKS_INDEX, $value);
     }
 
     // imports
     #[ArrayObjectPropertyTypeAttribute]
     public const string IMPORTS = 'imports';
-    protected const string IMPORTS_DATA_NAME = 'IMPORTS';
-    protected const int IMPORTS_DATA_INDEX = 5;
+    protected const int IMPORTS_INDEX = 5;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $imports {
-        get => $this->getData(self::IMPORTS_DATA_INDEX);
-        set => $this->setData(self::IMPORTS_DATA_INDEX, $value);
+        get => $this->getData(self::IMPORTS_INDEX);
+        set => $this->setData(self::IMPORTS_INDEX, $value);
     }
 
     // metaConstants
     #[ArrayObjectPropertyTypeAttribute]
     public const string META_CONSTANTS = 'metaConstants';
-    protected const string META_CONSTANTS_DATA_NAME = 'META_CONSTANTS';
-    protected const int META_CONSTANTS_DATA_INDEX = 6;
+    protected const int META_CONSTANTS_INDEX = 6;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $metaConstants {
-        get => $this->getData(self::META_CONSTANTS_DATA_INDEX);
-        set => $this->setData(self::META_CONSTANTS_DATA_INDEX, $value);
+        get => $this->getData(self::META_CONSTANTS_INDEX);
+        set => $this->setData(self::META_CONSTANTS_INDEX, $value);
     }
 
     // nullables
     #[ArrayObjectPropertyTypeAttribute]
     public const string NULLABLES = 'nullables';
-    protected const string NULLABLES_DATA_NAME = 'NULLABLES';
-    protected const int NULLABLES_DATA_INDEX = 7;
+    protected const int NULLABLES_INDEX = 7;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $nullables {
-        get => $this->getData(self::NULLABLES_DATA_INDEX);
-        set => $this->setData(self::NULLABLES_DATA_INDEX, $value);
+        get => $this->getData(self::NULLABLES_INDEX);
+        set => $this->setData(self::NULLABLES_INDEX, $value);
     }
 
     // properties
     #[ArrayObjectPropertyTypeAttribute]
     public const string PROPERTIES = 'properties';
-    protected const string PROPERTIES_DATA_NAME = 'PROPERTIES';
-    protected const int PROPERTIES_DATA_INDEX = 8;
+    protected const int PROPERTIES_INDEX = 8;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $properties {
-        get => $this->getData(self::PROPERTIES_DATA_INDEX);
-        set => $this->setData(self::PROPERTIES_DATA_INDEX, $value);
+        get => $this->getData(self::PROPERTIES_INDEX);
+        set => $this->setData(self::PROPERTIES_INDEX, $value);
     }
 
     // protects
     #[ArrayObjectPropertyTypeAttribute]
     public const string PROTECTS = 'protects';
-    protected const string PROTECTS_DATA_NAME = 'PROTECTS';
-    protected const int PROTECTS_DATA_INDEX = 9;
+    protected const int PROTECTS_INDEX = 9;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $protects {
-        get => $this->getData(self::PROTECTS_DATA_INDEX);
-        set => $this->setData(self::PROTECTS_DATA_INDEX, $value);
+        get => $this->getData(self::PROTECTS_INDEX);
+        set => $this->setData(self::PROTECTS_INDEX, $value);
     }
 }

--- a/src/Generated/TransferGeneratorBulkTransfer.php
+++ b/src/Generated/TransferGeneratorBulkTransfer.php
@@ -21,29 +21,27 @@ final class TransferGeneratorBulkTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::PROGRESS => self::PROGRESS_DATA_NAME,
-        self::VALIDATOR => self::VALIDATOR_DATA_NAME,
+        self::PROGRESS_INDEX => self::PROGRESS,
+        self::VALIDATOR_INDEX => self::VALIDATOR,
     ];
 
     // progress
     #[PropertyTypeAttribute(FileReaderProgressTransfer::class)]
     public const string PROGRESS = 'progress';
-    protected const string PROGRESS_DATA_NAME = 'PROGRESS';
-    protected const int PROGRESS_DATA_INDEX = 0;
+    protected const int PROGRESS_INDEX = 0;
 
     public FileReaderProgressTransfer $progress {
-        get => $this->getData(self::PROGRESS_DATA_INDEX);
-        set => $this->setData(self::PROGRESS_DATA_INDEX, $value);
+        get => $this->getData(self::PROGRESS_INDEX);
+        set => $this->setData(self::PROGRESS_INDEX, $value);
     }
 
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const string VALIDATOR_DATA_NAME = 'VALIDATOR';
-    protected const int VALIDATOR_DATA_INDEX = 1;
+    protected const int VALIDATOR_INDEX = 1;
 
     public ValidatorTransfer $validator {
-        get => $this->getData(self::VALIDATOR_DATA_INDEX);
-        set => $this->setData(self::VALIDATOR_DATA_INDEX, $value);
+        get => $this->getData(self::VALIDATOR_INDEX);
+        set => $this->setData(self::VALIDATOR_INDEX, $value);
     }
 }

--- a/src/Generated/TransferGeneratorContentTransfer.php
+++ b/src/Generated/TransferGeneratorContentTransfer.php
@@ -20,27 +20,25 @@ final class TransferGeneratorContentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CLASS_NAME => self::CLASS_NAME_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
+        self::CLASS_NAME_INDEX => self::CLASS_NAME,
+        self::CONTENT_INDEX => self::CONTENT,
     ];
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const string CLASS_NAME_DATA_NAME = 'CLASS_NAME';
-    protected const int CLASS_NAME_DATA_INDEX = 0;
+    protected const int CLASS_NAME_INDEX = 0;
 
     public protected(set) string $className {
-        get => $this->getData(self::CLASS_NAME_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAME_INDEX);
+        set => $this->setData(self::CLASS_NAME_INDEX, $value);
     }
 
     // content
     public const string CONTENT = 'content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     public protected(set) string $content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 }

--- a/src/Generated/TransferGeneratorTransfer.php
+++ b/src/Generated/TransferGeneratorTransfer.php
@@ -21,39 +21,36 @@ final class TransferGeneratorTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CLASS_NAME => self::CLASS_NAME_DATA_NAME,
-        self::FILE_NAME => self::FILE_NAME_DATA_NAME,
-        self::VALIDATOR => self::VALIDATOR_DATA_NAME,
+        self::CLASS_NAME_INDEX => self::CLASS_NAME,
+        self::FILE_NAME_INDEX => self::FILE_NAME,
+        self::VALIDATOR_INDEX => self::VALIDATOR,
     ];
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const string CLASS_NAME_DATA_NAME = 'CLASS_NAME';
-    protected const int CLASS_NAME_DATA_INDEX = 0;
+    protected const int CLASS_NAME_INDEX = 0;
 
     public ?string $className {
-        get => $this->getData(self::CLASS_NAME_DATA_INDEX);
-        set => $this->setData(self::CLASS_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::CLASS_NAME_INDEX);
+        set => $this->setData(self::CLASS_NAME_INDEX, $value);
     }
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const string FILE_NAME_DATA_NAME = 'FILE_NAME';
-    protected const int FILE_NAME_DATA_INDEX = 1;
+    protected const int FILE_NAME_INDEX = 1;
 
     public ?string $fileName {
-        get => $this->getData(self::FILE_NAME_DATA_INDEX);
-        set => $this->setData(self::FILE_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FILE_NAME_INDEX);
+        set => $this->setData(self::FILE_NAME_INDEX, $value);
     }
 
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const string VALIDATOR_DATA_NAME = 'VALIDATOR';
-    protected const int VALIDATOR_DATA_INDEX = 2;
+    protected const int VALIDATOR_INDEX = 2;
 
     public ValidatorTransfer $validator {
-        get => $this->getData(self::VALIDATOR_DATA_INDEX);
-        set => $this->setData(self::VALIDATOR_DATA_INDEX, $value);
+        get => $this->getData(self::VALIDATOR_INDEX);
+        set => $this->setData(self::VALIDATOR_INDEX, $value);
     }
 }

--- a/src/Generated/ValidatorMessageTransfer.php
+++ b/src/Generated/ValidatorMessageTransfer.php
@@ -20,27 +20,25 @@ final class ValidatorMessageTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ERROR_MESSAGE => self::ERROR_MESSAGE_DATA_NAME,
-        self::IS_VALID => self::IS_VALID_DATA_NAME,
+        self::ERROR_MESSAGE_INDEX => self::ERROR_MESSAGE,
+        self::IS_VALID_INDEX => self::IS_VALID,
     ];
 
     // errorMessage
     public const string ERROR_MESSAGE = 'errorMessage';
-    protected const string ERROR_MESSAGE_DATA_NAME = 'ERROR_MESSAGE';
-    protected const int ERROR_MESSAGE_DATA_INDEX = 0;
+    protected const int ERROR_MESSAGE_INDEX = 0;
 
     public protected(set) string $errorMessage {
-        get => $this->getData(self::ERROR_MESSAGE_DATA_INDEX);
-        set => $this->setData(self::ERROR_MESSAGE_DATA_INDEX, $value);
+        get => $this->getData(self::ERROR_MESSAGE_INDEX);
+        set => $this->setData(self::ERROR_MESSAGE_INDEX, $value);
     }
 
     // isValid
     public const string IS_VALID = 'isValid';
-    protected const string IS_VALID_DATA_NAME = 'IS_VALID';
-    protected const int IS_VALID_DATA_INDEX = 1;
+    protected const int IS_VALID_INDEX = 1;
 
     public protected(set) bool $isValid {
-        get => $this->getData(self::IS_VALID_DATA_INDEX);
-        set => $this->setData(self::IS_VALID_DATA_INDEX, $value);
+        get => $this->getData(self::IS_VALID_INDEX);
+        set => $this->setData(self::IS_VALID_INDEX, $value);
     }
 }

--- a/src/Generated/ValidatorTransfer.php
+++ b/src/Generated/ValidatorTransfer.php
@@ -22,29 +22,27 @@ final class ValidatorTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ERROR_MESSAGES => self::ERROR_MESSAGES_DATA_NAME,
-        self::IS_VALID => self::IS_VALID_DATA_NAME,
+        self::ERROR_MESSAGES_INDEX => self::ERROR_MESSAGES,
+        self::IS_VALID_INDEX => self::IS_VALID,
     ];
 
     // errorMessages
     #[CollectionPropertyTypeAttribute(ValidatorMessageTransfer::class)]
     public const string ERROR_MESSAGES = 'errorMessages';
-    protected const string ERROR_MESSAGES_DATA_NAME = 'ERROR_MESSAGES';
-    protected const int ERROR_MESSAGES_DATA_INDEX = 0;
+    protected const int ERROR_MESSAGES_INDEX = 0;
 
     /** @var \ArrayObject<int,ValidatorMessageTransfer> */
     public ArrayObject $errorMessages {
-        get => $this->getData(self::ERROR_MESSAGES_DATA_INDEX);
-        set => $this->setData(self::ERROR_MESSAGES_DATA_INDEX, $value);
+        get => $this->getData(self::ERROR_MESSAGES_INDEX);
+        set => $this->setData(self::ERROR_MESSAGES_INDEX, $value);
     }
 
     // isValid
     public const string IS_VALID = 'isValid';
-    protected const string IS_VALID_DATA_NAME = 'IS_VALID';
-    protected const int IS_VALID_DATA_INDEX = 1;
+    protected const int IS_VALID_INDEX = 1;
 
     public bool $isValid {
-        get => $this->getData(self::IS_VALID_DATA_INDEX);
-        set => $this->setData(self::IS_VALID_DATA_INDEX, $value);
+        get => $this->getData(self::IS_VALID_INDEX);
+        set => $this->setData(self::IS_VALID_INDEX, $value);
     }
 }

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -75,8 +75,8 @@ abstract class AbstractTransfer implements TransferInterface
 
     final public function getIterator(): Traversable
     {
-        foreach (static::META_DATA as $propertyName) {
-            yield $propertyName => $this->{$propertyName};
+        foreach ($this->_data as $index => $value) {
+            yield static::META_DATA[$index] => $value;
         }
     }
 

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -144,12 +144,10 @@ abstract class AbstractTransfer implements TransferInterface
 
     private function initData(): void
     {
-        $this->_data = new SplFixedArray(size: static::META_DATA_SIZE);
+        $this->_data = new SplFixedArray(static::META_DATA_SIZE);
 
-        /** @var array<string,int> $metaData */
-        $metaData = array_flip(static::META_DATA);
         foreach ($this->getInitialAttributes() as $propertyName => $attribute) {
-            $this->_data[$metaData[$propertyName]] = $attribute->getInitialValue();
+            $this->{$propertyName} = $attribute->getInitialValue();
         }
     }
 }

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -23,8 +23,6 @@ abstract class AbstractTransfer implements TransferInterface
      */
     protected const array META_DATA = [];
 
-    private const string DATA_INDEX_SUFFIX = '_DATA_INDEX';
-
     /**
      * @var \SplFixedArray<mixed>
      */
@@ -79,8 +77,8 @@ abstract class AbstractTransfer implements TransferInterface
 
     final public function getIterator(): Traversable
     {
-        foreach (static::META_DATA as $metaKey => $metaName) {
-            yield $metaKey => $this->{$metaKey};
+        foreach (static::META_DATA as $propertyName) {
+            yield $propertyName => $this->{$propertyName};
         }
     }
 
@@ -97,14 +95,14 @@ abstract class AbstractTransfer implements TransferInterface
         $data = [];
         $attributes = $this->getTypeAttributes();
 
-        foreach (static::META_DATA as $metaKey => $metaName) {
-            if (isset($attributes[$metaName])) {
-                $data[$metaKey] = $attributes[$metaName]->toArray($this->{$metaKey});
+        foreach (static::META_DATA as $propertyName) {
+            if (isset($attributes[$propertyName])) {
+                $data[$propertyName] = $attributes[$propertyName]->toArray($this->{$propertyName});
 
                 continue;
             }
 
-            $data[$metaKey] = $this->{$metaKey};
+            $data[$propertyName] = $this->{$propertyName};
         }
 
         return $data;
@@ -127,18 +125,18 @@ abstract class AbstractTransfer implements TransferInterface
         }
 
         $attributes = $this->getTypeAttributes();
-        foreach (static::META_DATA as $metaKey => $metaName) {
-            if (!isset($data[$metaKey])) {
+        foreach (static::META_DATA as $propertyName) {
+            if (!isset($data[$propertyName])) {
                 continue;
             }
 
-            if (isset($attributes[$metaName])) {
-                $this->{$metaKey} = $attributes[$metaName]->fromArray($data[$metaKey]);
+            if (isset($attributes[$propertyName])) {
+                $this->{$propertyName} = $attributes[$propertyName]->fromArray($data[$propertyName]);
 
                 continue;
             }
 
-            $this->{$metaKey} = $data[$metaKey];
+            $this->{$propertyName} = $data[$propertyName];
         }
 
         return $this;
@@ -156,12 +154,12 @@ abstract class AbstractTransfer implements TransferInterface
 
     private function initData(): void
     {
-        $this->_data = new SplFixedArray(static::META_DATA_SIZE);
+        $this->_data = new SplFixedArray(size: static::META_DATA_SIZE);
 
-        foreach ($this->getInitialAttributes() as $metaName => $attribute) {
-            $metaIndex = $metaName . self::DATA_INDEX_SUFFIX;
-            // @phpstan-ignore offsetAssign.dimType
-            $this->_data[static::{$metaIndex}] = $attribute->getInitialValue();
+        /** @var array<string, int> $metaData */
+        $metaData = array_flip(static::META_DATA);
+        foreach ($this->getInitialAttributes() as $propertyName => $attribute) {
+            $this->_data[$metaData[$propertyName]] = $attribute->getInitialValue();
         }
     }
 }

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -144,7 +144,7 @@ abstract class AbstractTransfer implements TransferInterface
 
     private function initData(): void
     {
-        $this->_data = new SplFixedArray(static::META_DATA_SIZE);
+        $this->_data = new SplFixedArray(size: static::META_DATA_SIZE);
 
         foreach ($this->getInitialAttributes() as $propertyName => $attribute) {
             $this->{$propertyName} = $attribute->getInitialValue();

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -112,12 +112,7 @@ abstract class AbstractTransfer implements TransferInterface
     {
         $this->initData();
 
-        $data = array_filter(
-            $data,
-            fn (mixed $value, string|int $key): bool => $value !== null && in_array($key, static::META_DATA, true),
-            ARRAY_FILTER_USE_BOTH,
-        );
-
+        $data = array_filter($data, $this->filterData(...), ARRAY_FILTER_USE_BOTH);
         if ($data === []) {
             return $this;
         }
@@ -130,6 +125,11 @@ abstract class AbstractTransfer implements TransferInterface
         }
 
         return $this;
+    }
+
+    private function filterData(mixed $value, string|int $key): bool
+    {
+        return $value !== null && in_array($key, static::META_DATA, true);
     }
 
     final protected function getData(int $index): mixed

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -93,10 +93,10 @@ abstract class AbstractTransfer implements TransferInterface
         $data = [];
         $attributes = $this->getTypeAttributes();
 
-        foreach (static::META_DATA as $propertyName) {
+        foreach (static::META_DATA as $index => $propertyName) {
             $data[$propertyName] = isset($attributes[$propertyName])
                 ? $attributes[$propertyName]->toArray($this->{$propertyName})
-                : $this->{$propertyName};
+                : $this->_data[$index];
         }
 
         return $data;

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -31,7 +31,7 @@ abstract class AbstractTransfer implements TransferInterface
     /**
      * @param array<string,mixed> $data
      *
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     final public function __construct(array $data = [])
     {
@@ -83,7 +83,7 @@ abstract class AbstractTransfer implements TransferInterface
     }
 
     /**
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     final public function __clone(): void
     {

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer;
 
-use Deprecated;
 use SplFixedArray;
 use Traversable;
 
@@ -13,7 +12,6 @@ use Traversable;
  */
 abstract class AbstractTransfer implements TransferInterface
 {
-    use FilterArrayTrait;
     use ConstantAttributeTrait;
 
     /**
@@ -102,14 +100,6 @@ abstract class AbstractTransfer implements TransferInterface
         }
 
         return $data;
-    }
-
-    #[Deprecated(message: 'Method will be removed in version 3.0.0. Use FilterArrayTrait instead.', since: '2.3.0')]
-    final public function toFilterArray(?callable $callback = null): array
-    {
-        $data = $this->toArray();
-
-        return $this->filterArrayRecursive($data, $callback);
     }
 
     final public function fromArray(array $data): static

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -30,12 +30,18 @@ abstract class AbstractTransfer implements TransferInterface
     private SplFixedArray $_data;
 
     /**
-     * @param array<string,mixed> $data
+     * @param array<string,mixed>|null $data
      *
      * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
-    final public function __construct(array $data = [])
+    final public function __construct(?array $data = null)
     {
+        if ($data === null) {
+            $this->initData();
+
+            return;
+        }
+
         $this->fromArray($data);
     }
 
@@ -106,17 +112,18 @@ abstract class AbstractTransfer implements TransferInterface
     {
         $this->initData();
 
+        $data = array_filter(
+            $data,
+            fn (mixed $value, string|int $key): bool => $value !== null && in_array($key, static::META_DATA, true),
+            ARRAY_FILTER_USE_BOTH,
+        );
+
         if ($data === []) {
             return $this;
         }
 
         $attributes = $this->getTypeAttributes();
-        foreach (static::META_DATA as $propertyName) {
-            $value = $data[$propertyName] ?? null;
-            if ($value === null) {
-                continue;
-            }
-
+        foreach ($data as $propertyName => $value) {
             $this->{$propertyName} = isset($attributes[$propertyName])
                 ? $attributes[$propertyName]->fromArray($value)
                 : $value;

--- a/src/Transfer/Attribute/DataAssertTrait.php
+++ b/src/Transfer/Attribute/DataAssertTrait.php
@@ -20,7 +20,7 @@ trait DataAssertTrait
         throw new PropertyTypeTransferException(
             sprintf(
                 'Data must be of type array, "%s" given.',
-                get_debug_type($data)
+                get_debug_type($data),
             ),
         );
     }
@@ -34,7 +34,7 @@ trait DataAssertTrait
             sprintf(
                 'Data must be of type %s, "%s" given.',
                 $expectedType,
-                get_debug_type($data)
+                get_debug_type($data),
             ),
         );
     }
@@ -51,7 +51,7 @@ trait DataAssertTrait
         throw new PropertyTypeTransferException(
             sprintf(
                 'Data must be of type string or integer, "%s" given.',
-                get_debug_type($data)
+                get_debug_type($data),
             ),
         );
     }

--- a/src/Transfer/Attribute/DataAssertTrait.php
+++ b/src/Transfer/Attribute/DataAssertTrait.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer\Attribute;
 
-use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
+use Picamator\TransferObject\Transfer\Exception\DataAssertTransferException;
 
 trait DataAssertTrait
 {
     /**
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     final protected function assertArray(mixed $data): void
     {
@@ -17,7 +17,7 @@ trait DataAssertTrait
             return;
         }
 
-        throw new PropertyTypeTransferException(
+        throw new DataAssertTransferException(
             sprintf(
                 'Data must be of type array, "%s" given.',
                 get_debug_type($data),
@@ -26,11 +26,11 @@ trait DataAssertTrait
     }
 
     /**
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     final protected function assertInvalidType(mixed $data, string $expectedType): never
     {
-        throw new PropertyTypeTransferException(
+        throw new DataAssertTransferException(
             sprintf(
                 'Data must be of type %s, "%s" given.',
                 $expectedType,
@@ -40,7 +40,7 @@ trait DataAssertTrait
     }
 
     /**
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     final protected function assertStringOrInt(mixed $data): void
     {
@@ -48,7 +48,7 @@ trait DataAssertTrait
             return;
         }
 
-        throw new PropertyTypeTransferException(
+        throw new DataAssertTransferException(
             sprintf(
                 'Data must be of type string or integer, "%s" given.',
                 get_debug_type($data),

--- a/src/Transfer/Attribute/InitialPropertyTypeAttributeInterface.php
+++ b/src/Transfer/Attribute/InitialPropertyTypeAttributeInterface.php
@@ -9,5 +9,8 @@ namespace Picamator\TransferObject\Transfer\Attribute;
  */
 interface InitialPropertyTypeAttributeInterface extends PropertyTypeAttributeInterface
 {
-    public function getInitialValue(): mixed;
+    /**
+     * @return iterable<mixed>
+     */
+    public function getInitialValue(): iterable;
 }

--- a/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
+++ b/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
@@ -10,8 +10,7 @@ namespace Picamator\TransferObject\Transfer\Attribute;
 interface PropertyTypeAttributeInterface
 {
     /**
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
-     * @throws \ReflectionException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     public function fromArray(mixed $data): mixed;
 

--- a/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
+++ b/src/Transfer/Attribute/PropertyTypeAttributeInterface.php
@@ -11,6 +11,7 @@ interface PropertyTypeAttributeInterface
 {
     /**
      * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \ReflectionException
      */
     public function fromArray(mixed $data): mixed;
 

--- a/src/Transfer/Attribute/TransferBuilderTrait.php
+++ b/src/Transfer/Attribute/TransferBuilderTrait.php
@@ -21,8 +21,6 @@ trait TransferBuilderTrait
 
     /**
      * @param class-string<AbstractTransfer|TransferInterface> $typeName
-     *
-     * @throws \ReflectionException
      */
     final protected function createTransfer(string $typeName, mixed $data): TransferInterface
     {

--- a/src/Transfer/ConstantAttributeTrait.php
+++ b/src/Transfer/ConstantAttributeTrait.php
@@ -17,7 +17,7 @@ trait ConstantAttributeTrait
     /**
      * @var \WeakReference<\ReflectionObject>|null
      */
-    private ?WeakReference $reflectionObjectReference = null;
+    private ?WeakReference $_reflectionObjectReference = null;
 
     /**
      * @return array<string, \Picamator\TransferObject\Transfer\Attribute\PropertyTypeAttributeInterface>
@@ -70,11 +70,11 @@ trait ConstantAttributeTrait
      */
     private function getReflectionConstants(): array
     {
-        $reflectionObject = $this->reflectionObjectReference?->get();
+        $reflectionObject = $this->_reflectionObjectReference?->get();
 
         if ($reflectionObject === null) {
             $reflectionObject = new ReflectionObject($this);
-            $this->reflectionObjectReference = WeakReference::create($reflectionObject);
+            $this->_reflectionObjectReference = WeakReference::create($reflectionObject);
         }
 
         return $reflectionObject->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);

--- a/src/Transfer/ConstantAttributeTrait.php
+++ b/src/Transfer/ConstantAttributeTrait.php
@@ -64,6 +64,7 @@ trait ConstantAttributeTrait
      */
     private function getReflectionConstants(): array
     {
-        return new ReflectionObject($this)->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);
+        return new ReflectionObject($this)
+            ->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);
     }
 }

--- a/src/Transfer/ConstantAttributeTrait.php
+++ b/src/Transfer/ConstantAttributeTrait.php
@@ -64,6 +64,6 @@ trait ConstantAttributeTrait
      */
     private function getReflectionConstants(): array
     {
-        return new ReflectionObject($this)->getReflectionConstants(ReflectionClassConstant::IS_PUBLIC);
+        return new ReflectionObject($this)->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);
     }
 }

--- a/src/Transfer/ConstantAttributeTrait.php
+++ b/src/Transfer/ConstantAttributeTrait.php
@@ -29,7 +29,9 @@ trait ConstantAttributeTrait
                 continue;
             }
 
-            $typeAttributes[$reflectionConstant->getName()] = $attributeReflections[0]->newInstance();
+            /** @var string $propertyName */
+            $propertyName = $reflectionConstant->getValue();
+            $typeAttributes[$propertyName] = $attributeReflections[0]->newInstance();
         }
 
         return $typeAttributes;
@@ -50,12 +52,15 @@ trait ConstantAttributeTrait
                 continue;
             }
 
-            yield $reflectionConstant->getName() => $attributeReflections[0]->newInstance();
+            /** @var string $propertyName */
+            $propertyName = $reflectionConstant->getValue();
+
+            yield $propertyName => $attributeReflections[0]->newInstance();
         }
     }
 
     /**
-     * @return array<int, \ReflectionClassConstant>
+     * @return array<\ReflectionClassConstant>
      */
     private function getReflectionConstants(): array
     {

--- a/src/Transfer/ConstantAttributeTrait.php
+++ b/src/Transfer/ConstantAttributeTrait.php
@@ -10,9 +10,15 @@ use Picamator\TransferObject\Transfer\Attribute\PropertyTypeAttributeInterface;
 use ReflectionAttribute;
 use ReflectionClassConstant;
 use ReflectionObject;
+use WeakReference;
 
 trait ConstantAttributeTrait
 {
+    /**
+     * @var \WeakReference<\ReflectionObject>|null
+     */
+    private ?WeakReference $reflectionObjectReference = null;
+
     /**
      * @return array<string, \Picamator\TransferObject\Transfer\Attribute\PropertyTypeAttributeInterface>
      */
@@ -64,7 +70,13 @@ trait ConstantAttributeTrait
      */
     private function getReflectionConstants(): array
     {
-        return new ReflectionObject($this)
-            ->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);
+        $reflectionObject = $this->reflectionObjectReference?->get();
+
+        if ($reflectionObject === null) {
+            $reflectionObject = new ReflectionObject($this);
+            $this->reflectionObjectReference = WeakReference::create($reflectionObject);
+        }
+
+        return $reflectionObject->getReflectionConstants(filter: ReflectionClassConstant::IS_PUBLIC);
     }
 }

--- a/src/Transfer/DummyTransferAdapterTrait.php
+++ b/src/Transfer/DummyTransferAdapterTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer;
 
-use Deprecated;
 use EmptyIterator;
 use Traversable;
 
@@ -20,8 +19,6 @@ use Traversable;
  */
 trait DummyTransferAdapterTrait
 {
-    use FilterArrayTrait;
-
     /**
      * @return Traversable<string, mixed>
      */
@@ -41,17 +38,6 @@ trait DummyTransferAdapterTrait
     public function toArray(): array
     {
         return [];
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    #[Deprecated(message: 'Method will be removed in version 3.0.0. Use FilterArrayTrait instead.', since: '2.3.0')]
-    public function toFilterArray(?callable $callback = null): array
-    {
-        $data = $this->toArray();
-
-        return $this->filterArrayRecursive($data, $callback);
     }
 
     /**

--- a/src/Transfer/Exception/DataAssertTransferException.php
+++ b/src/Transfer/Exception/DataAssertTransferException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer\Exception;
 
+use InvalidArgumentException;
 use Picamator\TransferObject\Shared\Exception\TransferExceptionInterface;
-use RuntimeException;
 
-class PropertyTypeTransferException extends RuntimeException implements TransferExceptionInterface
+class DataAssertTransferException extends InvalidArgumentException implements TransferExceptionInterface
 {
 }

--- a/src/Transfer/FilterArrayTrait.php
+++ b/src/Transfer/FilterArrayTrait.php
@@ -4,9 +4,20 @@ declare(strict_types=1);
 
 namespace Picamator\TransferObject\Transfer;
 
+/**
+ * @api
+ */
 trait FilterArrayTrait
 {
     /**
+     * Specification:
+     *  - Applies recursively a callback to each array's value.
+     *  - The callback works the same way as the PHP function `array_filter()`.
+     *  - When no callback is supplied, all empty entries will be removed (see PHP function `empty()`).
+     *
+     * @link https://www.php.net/manual/en/function.array-filter.php
+     * @link https://www.php.net/manual/en/function.empty.php
+     *
      * @param array<string,mixed> $data
      *
      * @return array<string,mixed>

--- a/src/Transfer/TransferAdapterTrait.php
+++ b/src/Transfer/TransferAdapterTrait.php
@@ -10,7 +10,7 @@ use BcMath\Number;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use ReflectionClass;
+use ReflectionObject;
 use ReflectionProperty;
 use stdClass;
 use Traversable;
@@ -167,13 +167,8 @@ trait TransferAdapterTrait
      */
     private function getPublicProperties(): array
     {
-        if (isset($this->_propertyCache)) {
-            return $this->_propertyCache;
-        }
-
-        $reflection = new ReflectionClass($this);
-
-        return $this->_propertyCache = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+        return $this->_propertyCache ??= new ReflectionObject($this)
+            ->getProperties(ReflectionProperty::IS_PUBLIC);
     }
 
     private function isBcMathLoaded(): bool

--- a/src/Transfer/TransferAdapterTrait.php
+++ b/src/Transfer/TransferAdapterTrait.php
@@ -10,7 +10,6 @@ use BcMath\Number;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Deprecated;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
@@ -31,8 +30,6 @@ use Traversable;
  */
 trait TransferAdapterTrait
 {
-    use FilterArrayTrait;
-
     protected const string DATE_TIME_FORMAT = 'Y-m-d H:i:s';
 
     /**
@@ -85,17 +82,6 @@ trait TransferAdapterTrait
         }
 
         return $data;
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    #[Deprecated(message: 'Method will be removed in version 3.0.0. Use FilterArrayTrait instead.', since: '2.3.0')]
-    public function toFilterArray(?callable $callback = null): array
-    {
-        $data = $this->toArray();
-
-        return $this->filterArrayRecursive($data, $callback);
     }
 
     /**

--- a/src/Transfer/TransferAdapterTrait.php
+++ b/src/Transfer/TransferAdapterTrait.php
@@ -168,7 +168,7 @@ trait TransferAdapterTrait
     private function getPublicProperties(): array
     {
         return $this->_propertyCache ??= new ReflectionObject($this)
-            ->getProperties(ReflectionProperty::IS_PUBLIC);
+            ->getProperties(filter: ReflectionProperty::IS_PUBLIC);
     }
 
     private function isBcMathLoaded(): bool

--- a/src/Transfer/TransferAdapterTrait.php
+++ b/src/Transfer/TransferAdapterTrait.php
@@ -43,8 +43,12 @@ trait TransferAdapterTrait
      */
     public function getIterator(): Traversable
     {
-        foreach ($this->getPublicProperties() as $property) {
-            $name = $property->getName();
+        foreach ($this->getPublicProperties() as $reflectionProperty) {
+            if (!$reflectionProperty->isInitialized($this)) {
+                continue;
+            }
+
+            $name = $reflectionProperty->getName();
 
             yield $name => $this->$name;
         }
@@ -61,8 +65,12 @@ trait TransferAdapterTrait
     public function toArray(): array
     {
         $data = [];
-        foreach ($this->getPublicProperties() as $property) {
-            $name = $property->getName();
+        foreach ($this->getPublicProperties() as $propertyReflection) {
+            if (!$propertyReflection->isInitialized($this)) {
+                continue;
+            }
+
+            $name = $propertyReflection->getName();
             $value = $this->$name;
 
             $data[$name] = match (true) {

--- a/src/Transfer/TransferAdapterTrait.php
+++ b/src/Transfer/TransferAdapterTrait.php
@@ -111,30 +111,30 @@ trait TransferAdapterTrait
                     => new $type($value),
 
                 $isArray && is_subclass_of($type, TransferInterface::class)
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => new $type()->fromArray($value),
 
                 $isArray && $type === ArrayObject::class
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => new ArrayObject($value),
 
                 $isStringOrInt && is_subclass_of($type, BackedEnum::class)
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => $type::tryFrom($value),
 
                 $isString && $type === DateTime::class
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => new DateTime($value),
 
                 $isString && $type === DateTimeImmutable::class
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => new DateTimeImmutable($value),
 
                 $isArray && $type === stdClass::class
                     => (object)$value,
 
                 $isStringOrInt && $this->isBcMathLoaded() && $type === Number::class
-                    //  @phpstan-ignore argument.type
+                    // @phpstan-ignore argument.type
                     => new Number($value),
 
                 default => $value,

--- a/src/Transfer/TransferInterface.php
+++ b/src/Transfer/TransferInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Picamator\TransferObject\Transfer;
 
 use Countable;
-use Deprecated;
 use IteratorAggregate;
 use JsonSerializable;
 
@@ -24,27 +23,6 @@ interface TransferInterface extends IteratorAggregate, JsonSerializable, Countab
      * @return array<string,mixed>
      */
     public function toArray(): array;
-
-    /**
-     * Specification:
-     * - Converts recursively transfer object to array.
-     * - Applies a callback to each transfer object property after converting to an array.
-     * - The callback works the same way as the PHP function `array_filter()`.
-     * - When no callback is supplied, all empty entries will be removed (see PHP function `empty()`).
-     *
-     * @link https://www.php.net/manual/en/function.array-filter.php
-     * @link https://www.php.net/manual/en/function.empty.php
-     *
-     * @api
-     *
-     * @deprecated Method will be removed in version 3.0.0. Use FilterArrayTrait instead.
-     *
-     * @param callable|null $callback Optional. A callback function to apply to each property.
-     *                                If null, empty entries will be removed.
-     * @return array<string,mixed>
-     */
-    #[Deprecated(message: 'Method will be removed in version 3.0.0. Use FilterArrayTrait instead.', since: '2.3.0')]
-    public function toFilterArray(?callable $callback = null): array;
 
     /**
      * Specification:

--- a/src/Transfer/TransferInterface.php
+++ b/src/Transfer/TransferInterface.php
@@ -56,6 +56,7 @@ interface TransferInterface extends IteratorAggregate, JsonSerializable, Countab
      * @param array<string,mixed> $data
      *
      * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
+     * @throws \ReflectionException
      */
     public function fromArray(array $data): static;
 }

--- a/src/Transfer/TransferInterface.php
+++ b/src/Transfer/TransferInterface.php
@@ -55,8 +55,7 @@ interface TransferInterface extends IteratorAggregate, JsonSerializable, Countab
      *
      * @param array<string,mixed> $data
      *
-     * @throws \Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException
-     * @throws \ReflectionException
+     * @throws \Picamator\TransferObject\Transfer\Exception\DataAssertTransferException
      */
     public function fromArray(array $data): static;
 }

--- a/src/TransferGenerator/Definition/Validator/Content/Property/NumberTypePropertyValidator.php
+++ b/src/TransferGenerator/Definition/Validator/Content/Property/NumberTypePropertyValidator.php
@@ -17,7 +17,7 @@ class NumberTypePropertyValidator implements PropertyValidatorInterface
         = 'Property "%s" type "%s" is not a BcMath\Number.';
 
     private const string EXTENSION_IS_NOT_LOADED_ERROR
-        = 'PHP extension BCMath was not loaded. Please install and load extension';
+        = 'PHP extension BCMath was not loaded. Please install and load extension.';
 
     public function isApplicable(DefinitionPropertyTransfer $propertyTransfer): bool
     {
@@ -50,12 +50,12 @@ class NumberTypePropertyValidator implements PropertyValidatorInterface
     {
         return sprintf(
             self::INVALID_NUMBER_TYPE_ERROR_MESSAGE_TEMPLATE,
-            $propertyTransfer->propertyName,
+            $propertyTransfer->propertyName ?? '',
             $propertyTransfer->numberType?->namespace->withoutAlias ?? '',
         );
     }
 
-    private function isBcMathLoaded(): bool
+    protected function isBcMathLoaded(): bool
     {
         return extension_loaded('bcmath');
     }

--- a/src/TransferGenerator/Definition/Validator/Content/Property/ReservedNamePropertyValidator.php
+++ b/src/TransferGenerator/Definition/Validator/Content/Property/ReservedNamePropertyValidator.php
@@ -14,11 +14,18 @@ class ReservedNamePropertyValidator implements PropertyValidatorInterface
 
     private const string RESERVED_NAME_ERROR_MESSAGE_TEMPLATE = 'Reserved property name "%s".';
 
-    private const string RESERVED_PROPERTY = '_data';
+    /**
+     * @uses \Picamator\TransferObject\Transfer\AbstractTransfer::_data
+     * @uses \Picamator\TransferObject\Transfer\ConstantAttributeTrait::_reflectionObjectReference
+     */
+    private const array RESERVED_PROPERTIES = [
+        '_data',
+        '_reflectionObjectReference',
+    ];
 
     public function isApplicable(DefinitionPropertyTransfer $propertyTransfer): bool
     {
-        return $propertyTransfer->propertyName === self::RESERVED_PROPERTY;
+        return in_array($propertyTransfer->propertyName, self::RESERVED_PROPERTIES, true);
     }
 
     public function validate(DefinitionPropertyTransfer $propertyTransfer): ValidatorMessageTransfer

--- a/src/TransferGenerator/Generator/Render/Template/Template.php
+++ b/src/TransferGenerator/Generator/Render/Template/Template.php
@@ -59,12 +59,11 @@ TEMPLATE;
 
     // $property{$this->helper->renderAttribute($property)}
     public const string $constant = '$property';
-    protected const string {$constant}_DATA_NAME = '$constant';
-    protected const int {$constant}_DATA_INDEX = $i;
+    protected const int {$constant}_INDEX = $i;
 {$this->helper->renderDockBlock($property)}
     public{$this->helper->renderPropertyDeclaration($property)} \$$property {
-        get => \$this->getData(self::{$constant}_DATA_INDEX);
-        set => \$this->setData(self::{$constant}_DATA_INDEX, \$value);
+        get => \$this->getData(self::{$constant}_INDEX);
+        set => \$this->setData(self::{$constant}_INDEX, \$value);
     }
 TEMPLATE;
             $i++;

--- a/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
+++ b/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
@@ -11,7 +11,7 @@ class TemplateHelper implements TemplateHelperInterface
     private TemplateTransfer $templateTransfer;
 
     private const string IMPORT_TEMPLATE = 'use %s;';
-    private const string META_DATA_TEMPLATE = '        self::%1$s => self::%1$s_DATA_NAME,';
+    private const string META_DATA_TEMPLATE = '        self::%1$s_INDEX => self::%1$s,';
 
     private const string PADDING_LEFT = PHP_EOL . '    ';
     private const string EMPTY_STRING = '';

--- a/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
+++ b/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
@@ -40,8 +40,8 @@ class TemplateHelper implements TemplateHelperInterface
     public function renderMetaData(): string
     {
         $metaData = [];
-        foreach ($this->templateTransfer->metaConstants as $key => $value) {
-            $metaData[] = sprintf(self::META_DATA_TEMPLATE, $key);
+        foreach (array_keys($this->templateTransfer->metaConstants->getArrayCopy()) as $value) {
+            $metaData[] = sprintf(self::META_DATA_TEMPLATE, $value);
         }
 
         return implode(PHP_EOL, $metaData);

--- a/tests/integration/Command/Generated/Success/CommandTransfer.php
+++ b/tests/integration/Command/Generated/Success/CommandTransfer.php
@@ -20,16 +20,15 @@ final class CommandTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::RUN => self::RUN_DATA_NAME,
+        self::RUN_INDEX => self::RUN,
     ];
 
     // run
     public const string RUN = 'run';
-    protected const string RUN_DATA_NAME = 'RUN';
-    protected const int RUN_DATA_INDEX = 0;
+    protected const int RUN_INDEX = 0;
 
     public ?true $run {
-        get => $this->getData(self::RUN_DATA_INDEX);
-        set => $this->setData(self::RUN_DATA_INDEX, $value);
+        get => $this->getData(self::RUN_INDEX);
+        set => $this->setData(self::RUN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/DestatisTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/DestatisTransfer.php
@@ -23,113 +23,104 @@ final class DestatisTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 9;
 
     protected const array META_DATA = [
-        self::COPYRIGHT => self::COPYRIGHT_DATA_NAME,
-        self::CUBES => self::CUBES_DATA_NAME,
-        self::IDENT => self::IDENT_DATA_NAME,
-        self::PARAMETER => self::PARAMETER_DATA_NAME,
-        self::STATISTICS => self::STATISTICS_DATA_NAME,
-        self::STATUS => self::STATUS_DATA_NAME,
-        self::TABLES => self::TABLES_DATA_NAME,
-        self::TIMESERIES => self::TIMESERIES_DATA_NAME,
-        self::VARIABLES => self::VARIABLES_DATA_NAME,
+        self::COPYRIGHT_INDEX => self::COPYRIGHT,
+        self::CUBES_INDEX => self::CUBES,
+        self::IDENT_INDEX => self::IDENT,
+        self::PARAMETER_INDEX => self::PARAMETER,
+        self::STATISTICS_INDEX => self::STATISTICS,
+        self::STATUS_INDEX => self::STATUS,
+        self::TABLES_INDEX => self::TABLES,
+        self::TIMESERIES_INDEX => self::TIMESERIES,
+        self::VARIABLES_INDEX => self::VARIABLES,
     ];
 
     // Copyright
     public const string COPYRIGHT = 'Copyright';
-    protected const string COPYRIGHT_DATA_NAME = 'COPYRIGHT';
-    protected const int COPYRIGHT_DATA_INDEX = 0;
+    protected const int COPYRIGHT_INDEX = 0;
 
     public ?string $Copyright {
-        get => $this->getData(self::COPYRIGHT_DATA_INDEX);
-        set => $this->setData(self::COPYRIGHT_DATA_INDEX, $value);
+        get => $this->getData(self::COPYRIGHT_INDEX);
+        set => $this->setData(self::COPYRIGHT_INDEX, $value);
     }
 
     // Cubes
     public const string CUBES = 'Cubes';
-    protected const string CUBES_DATA_NAME = 'CUBES';
-    protected const int CUBES_DATA_INDEX = 1;
+    protected const int CUBES_INDEX = 1;
 
     public ?string $Cubes {
-        get => $this->getData(self::CUBES_DATA_INDEX);
-        set => $this->setData(self::CUBES_DATA_INDEX, $value);
+        get => $this->getData(self::CUBES_INDEX);
+        set => $this->setData(self::CUBES_INDEX, $value);
     }
 
     // Ident
     #[PropertyTypeAttribute(IdentTransfer::class)]
     public const string IDENT = 'Ident';
-    protected const string IDENT_DATA_NAME = 'IDENT';
-    protected const int IDENT_DATA_INDEX = 2;
+    protected const int IDENT_INDEX = 2;
 
     public ?IdentTransfer $Ident {
-        get => $this->getData(self::IDENT_DATA_INDEX);
-        set => $this->setData(self::IDENT_DATA_INDEX, $value);
+        get => $this->getData(self::IDENT_INDEX);
+        set => $this->setData(self::IDENT_INDEX, $value);
     }
 
     // Parameter
     #[PropertyTypeAttribute(ParameterTransfer::class)]
     public const string PARAMETER = 'Parameter';
-    protected const string PARAMETER_DATA_NAME = 'PARAMETER';
-    protected const int PARAMETER_DATA_INDEX = 3;
+    protected const int PARAMETER_INDEX = 3;
 
     public ?ParameterTransfer $Parameter {
-        get => $this->getData(self::PARAMETER_DATA_INDEX);
-        set => $this->setData(self::PARAMETER_DATA_INDEX, $value);
+        get => $this->getData(self::PARAMETER_INDEX);
+        set => $this->setData(self::PARAMETER_INDEX, $value);
     }
 
     // Statistics
     #[CollectionPropertyTypeAttribute(StatisticsTransfer::class)]
     public const string STATISTICS = 'Statistics';
-    protected const string STATISTICS_DATA_NAME = 'STATISTICS';
-    protected const int STATISTICS_DATA_INDEX = 4;
+    protected const int STATISTICS_INDEX = 4;
 
     /** @var \ArrayObject<int,StatisticsTransfer> */
     public ArrayObject $Statistics {
-        get => $this->getData(self::STATISTICS_DATA_INDEX);
-        set => $this->setData(self::STATISTICS_DATA_INDEX, $value);
+        get => $this->getData(self::STATISTICS_INDEX);
+        set => $this->setData(self::STATISTICS_INDEX, $value);
     }
 
     // Status
     #[PropertyTypeAttribute(StatusTransfer::class)]
     public const string STATUS = 'Status';
-    protected const string STATUS_DATA_NAME = 'STATUS';
-    protected const int STATUS_DATA_INDEX = 5;
+    protected const int STATUS_INDEX = 5;
 
     public ?StatusTransfer $Status {
-        get => $this->getData(self::STATUS_DATA_INDEX);
-        set => $this->setData(self::STATUS_DATA_INDEX, $value);
+        get => $this->getData(self::STATUS_INDEX);
+        set => $this->setData(self::STATUS_INDEX, $value);
     }
 
     // Tables
     #[CollectionPropertyTypeAttribute(TablesTransfer::class)]
     public const string TABLES = 'Tables';
-    protected const string TABLES_DATA_NAME = 'TABLES';
-    protected const int TABLES_DATA_INDEX = 6;
+    protected const int TABLES_INDEX = 6;
 
     /** @var \ArrayObject<int,TablesTransfer> */
     public ArrayObject $Tables {
-        get => $this->getData(self::TABLES_DATA_INDEX);
-        set => $this->setData(self::TABLES_DATA_INDEX, $value);
+        get => $this->getData(self::TABLES_INDEX);
+        set => $this->setData(self::TABLES_INDEX, $value);
     }
 
     // Timeseries
     public const string TIMESERIES = 'Timeseries';
-    protected const string TIMESERIES_DATA_NAME = 'TIMESERIES';
-    protected const int TIMESERIES_DATA_INDEX = 7;
+    protected const int TIMESERIES_INDEX = 7;
 
     public ?string $Timeseries {
-        get => $this->getData(self::TIMESERIES_DATA_INDEX);
-        set => $this->setData(self::TIMESERIES_DATA_INDEX, $value);
+        get => $this->getData(self::TIMESERIES_INDEX);
+        set => $this->setData(self::TIMESERIES_INDEX, $value);
     }
 
     // Variables
     #[CollectionPropertyTypeAttribute(VariablesTransfer::class)]
     public const string VARIABLES = 'Variables';
-    protected const string VARIABLES_DATA_NAME = 'VARIABLES';
-    protected const int VARIABLES_DATA_INDEX = 8;
+    protected const int VARIABLES_INDEX = 8;
 
     /** @var \ArrayObject<int,VariablesTransfer> */
     public ArrayObject $Variables {
-        get => $this->getData(self::VARIABLES_DATA_INDEX);
-        set => $this->setData(self::VARIABLES_DATA_INDEX, $value);
+        get => $this->getData(self::VARIABLES_INDEX);
+        set => $this->setData(self::VARIABLES_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/IdentTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/IdentTransfer.php
@@ -20,27 +20,25 @@ final class IdentTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::METHOD => self::METHOD_DATA_NAME,
-        self::SERVICE => self::SERVICE_DATA_NAME,
+        self::METHOD_INDEX => self::METHOD,
+        self::SERVICE_INDEX => self::SERVICE,
     ];
 
     // Method
     public const string METHOD = 'Method';
-    protected const string METHOD_DATA_NAME = 'METHOD';
-    protected const int METHOD_DATA_INDEX = 0;
+    protected const int METHOD_INDEX = 0;
 
     public ?string $Method {
-        get => $this->getData(self::METHOD_DATA_INDEX);
-        set => $this->setData(self::METHOD_DATA_INDEX, $value);
+        get => $this->getData(self::METHOD_INDEX);
+        set => $this->setData(self::METHOD_INDEX, $value);
     }
 
     // Service
     public const string SERVICE = 'Service';
-    protected const string SERVICE_DATA_NAME = 'SERVICE';
-    protected const int SERVICE_DATA_INDEX = 1;
+    protected const int SERVICE_INDEX = 1;
 
     public ?string $Service {
-        get => $this->getData(self::SERVICE_DATA_INDEX);
-        set => $this->setData(self::SERVICE_DATA_INDEX, $value);
+        get => $this->getData(self::SERVICE_INDEX);
+        set => $this->setData(self::SERVICE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/ParameterTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/ParameterTransfer.php
@@ -20,71 +20,65 @@ final class ParameterTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 6;
 
     protected const array META_DATA = [
-        self::CATEGORY => self::CATEGORY_DATA_NAME,
-        self::LANGUAGE => self::LANGUAGE_DATA_NAME,
-        self::PAGELENGTH => self::PAGELENGTH_DATA_NAME,
-        self::PASSWORD => self::PASSWORD_DATA_NAME,
-        self::TERM => self::TERM_DATA_NAME,
-        self::USERNAME => self::USERNAME_DATA_NAME,
+        self::CATEGORY_INDEX => self::CATEGORY,
+        self::LANGUAGE_INDEX => self::LANGUAGE,
+        self::PAGELENGTH_INDEX => self::PAGELENGTH,
+        self::PASSWORD_INDEX => self::PASSWORD,
+        self::TERM_INDEX => self::TERM,
+        self::USERNAME_INDEX => self::USERNAME,
     ];
 
     // category
     public const string CATEGORY = 'category';
-    protected const string CATEGORY_DATA_NAME = 'CATEGORY';
-    protected const int CATEGORY_DATA_INDEX = 0;
+    protected const int CATEGORY_INDEX = 0;
 
     public ?string $category {
-        get => $this->getData(self::CATEGORY_DATA_INDEX);
-        set => $this->setData(self::CATEGORY_DATA_INDEX, $value);
+        get => $this->getData(self::CATEGORY_INDEX);
+        set => $this->setData(self::CATEGORY_INDEX, $value);
     }
 
     // language
     public const string LANGUAGE = 'language';
-    protected const string LANGUAGE_DATA_NAME = 'LANGUAGE';
-    protected const int LANGUAGE_DATA_INDEX = 1;
+    protected const int LANGUAGE_INDEX = 1;
 
     public ?string $language {
-        get => $this->getData(self::LANGUAGE_DATA_INDEX);
-        set => $this->setData(self::LANGUAGE_DATA_INDEX, $value);
+        get => $this->getData(self::LANGUAGE_INDEX);
+        set => $this->setData(self::LANGUAGE_INDEX, $value);
     }
 
     // pagelength
     public const string PAGELENGTH = 'pagelength';
-    protected const string PAGELENGTH_DATA_NAME = 'PAGELENGTH';
-    protected const int PAGELENGTH_DATA_INDEX = 2;
+    protected const int PAGELENGTH_INDEX = 2;
 
     public ?string $pagelength {
-        get => $this->getData(self::PAGELENGTH_DATA_INDEX);
-        set => $this->setData(self::PAGELENGTH_DATA_INDEX, $value);
+        get => $this->getData(self::PAGELENGTH_INDEX);
+        set => $this->setData(self::PAGELENGTH_INDEX, $value);
     }
 
     // password
     public const string PASSWORD = 'password';
-    protected const string PASSWORD_DATA_NAME = 'PASSWORD';
-    protected const int PASSWORD_DATA_INDEX = 3;
+    protected const int PASSWORD_INDEX = 3;
 
     public ?string $password {
-        get => $this->getData(self::PASSWORD_DATA_INDEX);
-        set => $this->setData(self::PASSWORD_DATA_INDEX, $value);
+        get => $this->getData(self::PASSWORD_INDEX);
+        set => $this->setData(self::PASSWORD_INDEX, $value);
     }
 
     // term
     public const string TERM = 'term';
-    protected const string TERM_DATA_NAME = 'TERM';
-    protected const int TERM_DATA_INDEX = 4;
+    protected const int TERM_INDEX = 4;
 
     public ?string $term {
-        get => $this->getData(self::TERM_DATA_INDEX);
-        set => $this->setData(self::TERM_DATA_INDEX, $value);
+        get => $this->getData(self::TERM_INDEX);
+        set => $this->setData(self::TERM_INDEX, $value);
     }
 
     // username
     public const string USERNAME = 'username';
-    protected const string USERNAME_DATA_NAME = 'USERNAME';
-    protected const int USERNAME_DATA_INDEX = 5;
+    protected const int USERNAME_INDEX = 5;
 
     public ?string $username {
-        get => $this->getData(self::USERNAME_DATA_INDEX);
-        set => $this->setData(self::USERNAME_DATA_INDEX, $value);
+        get => $this->getData(self::USERNAME_INDEX);
+        set => $this->setData(self::USERNAME_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/StatisticsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/StatisticsTransfer.php
@@ -20,49 +20,45 @@ final class StatisticsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::CODE => self::CODE_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::CUBES => self::CUBES_DATA_NAME,
-        self::INFORMATION => self::INFORMATION_DATA_NAME,
+        self::CODE_INDEX => self::CODE,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::CUBES_INDEX => self::CUBES,
+        self::INFORMATION_INDEX => self::INFORMATION,
     ];
 
     // Code
     public const string CODE = 'Code';
-    protected const string CODE_DATA_NAME = 'CODE';
-    protected const int CODE_DATA_INDEX = 0;
+    protected const int CODE_INDEX = 0;
 
     public ?string $Code {
-        get => $this->getData(self::CODE_DATA_INDEX);
-        set => $this->setData(self::CODE_DATA_INDEX, $value);
+        get => $this->getData(self::CODE_INDEX);
+        set => $this->setData(self::CODE_INDEX, $value);
     }
 
     // Content
     public const string CONTENT = 'Content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     public ?string $Content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // Cubes
     public const string CUBES = 'Cubes';
-    protected const string CUBES_DATA_NAME = 'CUBES';
-    protected const int CUBES_DATA_INDEX = 2;
+    protected const int CUBES_INDEX = 2;
 
     public ?string $Cubes {
-        get => $this->getData(self::CUBES_DATA_INDEX);
-        set => $this->setData(self::CUBES_DATA_INDEX, $value);
+        get => $this->getData(self::CUBES_INDEX);
+        set => $this->setData(self::CUBES_INDEX, $value);
     }
 
     // Information
     public const string INFORMATION = 'Information';
-    protected const string INFORMATION_DATA_NAME = 'INFORMATION';
-    protected const int INFORMATION_DATA_INDEX = 3;
+    protected const int INFORMATION_INDEX = 3;
 
     public ?string $Information {
-        get => $this->getData(self::INFORMATION_DATA_INDEX);
-        set => $this->setData(self::INFORMATION_DATA_INDEX, $value);
+        get => $this->getData(self::INFORMATION_INDEX);
+        set => $this->setData(self::INFORMATION_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/StatusTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/StatusTransfer.php
@@ -20,38 +20,35 @@ final class StatusTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CODE => self::CODE_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::CODE_INDEX => self::CODE,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // Code
     public const string CODE = 'Code';
-    protected const string CODE_DATA_NAME = 'CODE';
-    protected const int CODE_DATA_INDEX = 0;
+    protected const int CODE_INDEX = 0;
 
     public ?int $Code {
-        get => $this->getData(self::CODE_DATA_INDEX);
-        set => $this->setData(self::CODE_DATA_INDEX, $value);
+        get => $this->getData(self::CODE_INDEX);
+        set => $this->setData(self::CODE_INDEX, $value);
     }
 
     // Content
     public const string CONTENT = 'Content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     public ?string $Content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // Type
     public const string TYPE = 'Type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 2;
+    protected const int TYPE_INDEX = 2;
 
     public ?string $Type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/TablesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/TablesTransfer.php
@@ -20,38 +20,35 @@ final class TablesTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::CODE => self::CODE_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::TIME => self::TIME_DATA_NAME,
+        self::CODE_INDEX => self::CODE,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::TIME_INDEX => self::TIME,
     ];
 
     // Code
     public const string CODE = 'Code';
-    protected const string CODE_DATA_NAME = 'CODE';
-    protected const int CODE_DATA_INDEX = 0;
+    protected const int CODE_INDEX = 0;
 
     public ?string $Code {
-        get => $this->getData(self::CODE_DATA_INDEX);
-        set => $this->setData(self::CODE_DATA_INDEX, $value);
+        get => $this->getData(self::CODE_INDEX);
+        set => $this->setData(self::CODE_INDEX, $value);
     }
 
     // Content
     public const string CONTENT = 'Content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     public ?string $Content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // Time
     public const string TIME = 'Time';
-    protected const string TIME_DATA_NAME = 'TIME';
-    protected const int TIME_DATA_INDEX = 2;
+    protected const int TIME_INDEX = 2;
 
     public ?string $Time {
-        get => $this->getData(self::TIME_DATA_INDEX);
-        set => $this->setData(self::TIME_DATA_INDEX, $value);
+        get => $this->getData(self::TIME_INDEX);
+        set => $this->setData(self::TIME_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/VariablesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/VariablesTransfer.php
@@ -20,60 +20,55 @@ final class VariablesTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 5;
 
     protected const array META_DATA = [
-        self::CODE => self::CODE_DATA_NAME,
-        self::CONTENT => self::CONTENT_DATA_NAME,
-        self::INFORMATION => self::INFORMATION_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
-        self::VALUES => self::VALUES_DATA_NAME,
+        self::CODE_INDEX => self::CODE,
+        self::CONTENT_INDEX => self::CONTENT,
+        self::INFORMATION_INDEX => self::INFORMATION,
+        self::TYPE_INDEX => self::TYPE,
+        self::VALUES_INDEX => self::VALUES,
     ];
 
     // Code
     public const string CODE = 'Code';
-    protected const string CODE_DATA_NAME = 'CODE';
-    protected const int CODE_DATA_INDEX = 0;
+    protected const int CODE_INDEX = 0;
 
     public ?string $Code {
-        get => $this->getData(self::CODE_DATA_INDEX);
-        set => $this->setData(self::CODE_DATA_INDEX, $value);
+        get => $this->getData(self::CODE_INDEX);
+        set => $this->setData(self::CODE_INDEX, $value);
     }
 
     // Content
     public const string CONTENT = 'Content';
-    protected const string CONTENT_DATA_NAME = 'CONTENT';
-    protected const int CONTENT_DATA_INDEX = 1;
+    protected const int CONTENT_INDEX = 1;
 
     public ?string $Content {
-        get => $this->getData(self::CONTENT_DATA_INDEX);
-        set => $this->setData(self::CONTENT_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_INDEX);
+        set => $this->setData(self::CONTENT_INDEX, $value);
     }
 
     // Information
     public const string INFORMATION = 'Information';
-    protected const string INFORMATION_DATA_NAME = 'INFORMATION';
-    protected const int INFORMATION_DATA_INDEX = 2;
+    protected const int INFORMATION_INDEX = 2;
 
     public ?string $Information {
-        get => $this->getData(self::INFORMATION_DATA_INDEX);
-        set => $this->setData(self::INFORMATION_DATA_INDEX, $value);
+        get => $this->getData(self::INFORMATION_INDEX);
+        set => $this->setData(self::INFORMATION_INDEX, $value);
     }
 
     // Type
     public const string TYPE = 'Type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 3;
+    protected const int TYPE_INDEX = 3;
 
     public ?string $Type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 
     // Values
     public const string VALUES = 'Values';
-    protected const string VALUES_DATA_NAME = 'VALUES';
-    protected const int VALUES_DATA_INDEX = 4;
+    protected const int VALUES_INDEX = 4;
 
     public ?string $Values {
-        get => $this->getData(self::VALUES_DATA_INDEX);
-        set => $this->setData(self::VALUES_DATA_INDEX, $value);
+        get => $this->getData(self::VALUES_INDEX);
+        set => $this->setData(self::VALUES_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Frankfurter/ExchangeRateTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Frankfurter/ExchangeRateTransfer.php
@@ -21,50 +21,46 @@ final class ExchangeRateTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::AMOUNT => self::AMOUNT_DATA_NAME,
-        self::BASE => self::BASE_DATA_NAME,
-        self::DATE => self::DATE_DATA_NAME,
-        self::RATES => self::RATES_DATA_NAME,
+        self::AMOUNT_INDEX => self::AMOUNT,
+        self::BASE_INDEX => self::BASE,
+        self::DATE_INDEX => self::DATE,
+        self::RATES_INDEX => self::RATES,
     ];
 
     // amount
     public const string AMOUNT = 'amount';
-    protected const string AMOUNT_DATA_NAME = 'AMOUNT';
-    protected const int AMOUNT_DATA_INDEX = 0;
+    protected const int AMOUNT_INDEX = 0;
 
     public ?int $amount {
-        get => $this->getData(self::AMOUNT_DATA_INDEX);
-        set => $this->setData(self::AMOUNT_DATA_INDEX, $value);
+        get => $this->getData(self::AMOUNT_INDEX);
+        set => $this->setData(self::AMOUNT_INDEX, $value);
     }
 
     // base
     public const string BASE = 'base';
-    protected const string BASE_DATA_NAME = 'BASE';
-    protected const int BASE_DATA_INDEX = 1;
+    protected const int BASE_INDEX = 1;
 
     public ?string $base {
-        get => $this->getData(self::BASE_DATA_INDEX);
-        set => $this->setData(self::BASE_DATA_INDEX, $value);
+        get => $this->getData(self::BASE_INDEX);
+        set => $this->setData(self::BASE_INDEX, $value);
     }
 
     // date
     public const string DATE = 'date';
-    protected const string DATE_DATA_NAME = 'DATE';
-    protected const int DATE_DATA_INDEX = 2;
+    protected const int DATE_INDEX = 2;
 
     public ?string $date {
-        get => $this->getData(self::DATE_DATA_INDEX);
-        set => $this->setData(self::DATE_DATA_INDEX, $value);
+        get => $this->getData(self::DATE_INDEX);
+        set => $this->setData(self::DATE_INDEX, $value);
     }
 
     // rates
     #[PropertyTypeAttribute(RatesTransfer::class)]
     public const string RATES = 'rates';
-    protected const string RATES_DATA_NAME = 'RATES';
-    protected const int RATES_DATA_INDEX = 3;
+    protected const int RATES_INDEX = 3;
 
     public ?RatesTransfer $rates {
-        get => $this->getData(self::RATES_DATA_INDEX);
-        set => $this->setData(self::RATES_DATA_INDEX, $value);
+        get => $this->getData(self::RATES_INDEX);
+        set => $this->setData(self::RATES_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Frankfurter/RatesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Frankfurter/RatesTransfer.php
@@ -20,335 +20,305 @@ final class RatesTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 30;
 
     protected const array META_DATA = [
-        self::AUD => self::AUD_DATA_NAME,
-        self::BGN => self::BGN_DATA_NAME,
-        self::BRL => self::BRL_DATA_NAME,
-        self::CAD => self::CAD_DATA_NAME,
-        self::CHF => self::CHF_DATA_NAME,
-        self::CNY => self::CNY_DATA_NAME,
-        self::CZK => self::CZK_DATA_NAME,
-        self::DKK => self::DKK_DATA_NAME,
-        self::GBP => self::GBP_DATA_NAME,
-        self::HKD => self::HKD_DATA_NAME,
-        self::HUF => self::HUF_DATA_NAME,
-        self::IDR => self::IDR_DATA_NAME,
-        self::ILS => self::ILS_DATA_NAME,
-        self::INR => self::INR_DATA_NAME,
-        self::ISK => self::ISK_DATA_NAME,
-        self::JPY => self::JPY_DATA_NAME,
-        self::KRW => self::KRW_DATA_NAME,
-        self::MXN => self::MXN_DATA_NAME,
-        self::MYR => self::MYR_DATA_NAME,
-        self::NOK => self::NOK_DATA_NAME,
-        self::NZD => self::NZD_DATA_NAME,
-        self::PHP => self::PHP_DATA_NAME,
-        self::PLN => self::PLN_DATA_NAME,
-        self::RON => self::RON_DATA_NAME,
-        self::SEK => self::SEK_DATA_NAME,
-        self::SGD => self::SGD_DATA_NAME,
-        self::THB => self::THB_DATA_NAME,
-        self::TRY => self::TRY_DATA_NAME,
-        self::USD => self::USD_DATA_NAME,
-        self::ZAR => self::ZAR_DATA_NAME,
+        self::AUD_INDEX => self::AUD,
+        self::BGN_INDEX => self::BGN,
+        self::BRL_INDEX => self::BRL,
+        self::CAD_INDEX => self::CAD,
+        self::CHF_INDEX => self::CHF,
+        self::CNY_INDEX => self::CNY,
+        self::CZK_INDEX => self::CZK,
+        self::DKK_INDEX => self::DKK,
+        self::GBP_INDEX => self::GBP,
+        self::HKD_INDEX => self::HKD,
+        self::HUF_INDEX => self::HUF,
+        self::IDR_INDEX => self::IDR,
+        self::ILS_INDEX => self::ILS,
+        self::INR_INDEX => self::INR,
+        self::ISK_INDEX => self::ISK,
+        self::JPY_INDEX => self::JPY,
+        self::KRW_INDEX => self::KRW,
+        self::MXN_INDEX => self::MXN,
+        self::MYR_INDEX => self::MYR,
+        self::NOK_INDEX => self::NOK,
+        self::NZD_INDEX => self::NZD,
+        self::PHP_INDEX => self::PHP,
+        self::PLN_INDEX => self::PLN,
+        self::RON_INDEX => self::RON,
+        self::SEK_INDEX => self::SEK,
+        self::SGD_INDEX => self::SGD,
+        self::THB_INDEX => self::THB,
+        self::TRY_INDEX => self::TRY,
+        self::USD_INDEX => self::USD,
+        self::ZAR_INDEX => self::ZAR,
     ];
 
     // AUD
     public const string AUD = 'AUD';
-    protected const string AUD_DATA_NAME = 'AUD';
-    protected const int AUD_DATA_INDEX = 0;
+    protected const int AUD_INDEX = 0;
 
     public ?float $AUD {
-        get => $this->getData(self::AUD_DATA_INDEX);
-        set => $this->setData(self::AUD_DATA_INDEX, $value);
+        get => $this->getData(self::AUD_INDEX);
+        set => $this->setData(self::AUD_INDEX, $value);
     }
 
     // BGN
     public const string BGN = 'BGN';
-    protected const string BGN_DATA_NAME = 'BGN';
-    protected const int BGN_DATA_INDEX = 1;
+    protected const int BGN_INDEX = 1;
 
     public ?float $BGN {
-        get => $this->getData(self::BGN_DATA_INDEX);
-        set => $this->setData(self::BGN_DATA_INDEX, $value);
+        get => $this->getData(self::BGN_INDEX);
+        set => $this->setData(self::BGN_INDEX, $value);
     }
 
     // BRL
     public const string BRL = 'BRL';
-    protected const string BRL_DATA_NAME = 'BRL';
-    protected const int BRL_DATA_INDEX = 2;
+    protected const int BRL_INDEX = 2;
 
     public ?float $BRL {
-        get => $this->getData(self::BRL_DATA_INDEX);
-        set => $this->setData(self::BRL_DATA_INDEX, $value);
+        get => $this->getData(self::BRL_INDEX);
+        set => $this->setData(self::BRL_INDEX, $value);
     }
 
     // CAD
     public const string CAD = 'CAD';
-    protected const string CAD_DATA_NAME = 'CAD';
-    protected const int CAD_DATA_INDEX = 3;
+    protected const int CAD_INDEX = 3;
 
     public ?float $CAD {
-        get => $this->getData(self::CAD_DATA_INDEX);
-        set => $this->setData(self::CAD_DATA_INDEX, $value);
+        get => $this->getData(self::CAD_INDEX);
+        set => $this->setData(self::CAD_INDEX, $value);
     }
 
     // CHF
     public const string CHF = 'CHF';
-    protected const string CHF_DATA_NAME = 'CHF';
-    protected const int CHF_DATA_INDEX = 4;
+    protected const int CHF_INDEX = 4;
 
     public ?float $CHF {
-        get => $this->getData(self::CHF_DATA_INDEX);
-        set => $this->setData(self::CHF_DATA_INDEX, $value);
+        get => $this->getData(self::CHF_INDEX);
+        set => $this->setData(self::CHF_INDEX, $value);
     }
 
     // CNY
     public const string CNY = 'CNY';
-    protected const string CNY_DATA_NAME = 'CNY';
-    protected const int CNY_DATA_INDEX = 5;
+    protected const int CNY_INDEX = 5;
 
     public ?float $CNY {
-        get => $this->getData(self::CNY_DATA_INDEX);
-        set => $this->setData(self::CNY_DATA_INDEX, $value);
+        get => $this->getData(self::CNY_INDEX);
+        set => $this->setData(self::CNY_INDEX, $value);
     }
 
     // CZK
     public const string CZK = 'CZK';
-    protected const string CZK_DATA_NAME = 'CZK';
-    protected const int CZK_DATA_INDEX = 6;
+    protected const int CZK_INDEX = 6;
 
     public ?float $CZK {
-        get => $this->getData(self::CZK_DATA_INDEX);
-        set => $this->setData(self::CZK_DATA_INDEX, $value);
+        get => $this->getData(self::CZK_INDEX);
+        set => $this->setData(self::CZK_INDEX, $value);
     }
 
     // DKK
     public const string DKK = 'DKK';
-    protected const string DKK_DATA_NAME = 'DKK';
-    protected const int DKK_DATA_INDEX = 7;
+    protected const int DKK_INDEX = 7;
 
     public ?float $DKK {
-        get => $this->getData(self::DKK_DATA_INDEX);
-        set => $this->setData(self::DKK_DATA_INDEX, $value);
+        get => $this->getData(self::DKK_INDEX);
+        set => $this->setData(self::DKK_INDEX, $value);
     }
 
     // GBP
     public const string GBP = 'GBP';
-    protected const string GBP_DATA_NAME = 'GBP';
-    protected const int GBP_DATA_INDEX = 8;
+    protected const int GBP_INDEX = 8;
 
     public ?float $GBP {
-        get => $this->getData(self::GBP_DATA_INDEX);
-        set => $this->setData(self::GBP_DATA_INDEX, $value);
+        get => $this->getData(self::GBP_INDEX);
+        set => $this->setData(self::GBP_INDEX, $value);
     }
 
     // HKD
     public const string HKD = 'HKD';
-    protected const string HKD_DATA_NAME = 'HKD';
-    protected const int HKD_DATA_INDEX = 9;
+    protected const int HKD_INDEX = 9;
 
     public ?float $HKD {
-        get => $this->getData(self::HKD_DATA_INDEX);
-        set => $this->setData(self::HKD_DATA_INDEX, $value);
+        get => $this->getData(self::HKD_INDEX);
+        set => $this->setData(self::HKD_INDEX, $value);
     }
 
     // HUF
     public const string HUF = 'HUF';
-    protected const string HUF_DATA_NAME = 'HUF';
-    protected const int HUF_DATA_INDEX = 10;
+    protected const int HUF_INDEX = 10;
 
     public ?float $HUF {
-        get => $this->getData(self::HUF_DATA_INDEX);
-        set => $this->setData(self::HUF_DATA_INDEX, $value);
+        get => $this->getData(self::HUF_INDEX);
+        set => $this->setData(self::HUF_INDEX, $value);
     }
 
     // IDR
     public const string IDR = 'IDR';
-    protected const string IDR_DATA_NAME = 'IDR';
-    protected const int IDR_DATA_INDEX = 11;
+    protected const int IDR_INDEX = 11;
 
     public ?int $IDR {
-        get => $this->getData(self::IDR_DATA_INDEX);
-        set => $this->setData(self::IDR_DATA_INDEX, $value);
+        get => $this->getData(self::IDR_INDEX);
+        set => $this->setData(self::IDR_INDEX, $value);
     }
 
     // ILS
     public const string ILS = 'ILS';
-    protected const string ILS_DATA_NAME = 'ILS';
-    protected const int ILS_DATA_INDEX = 12;
+    protected const int ILS_INDEX = 12;
 
     public ?float $ILS {
-        get => $this->getData(self::ILS_DATA_INDEX);
-        set => $this->setData(self::ILS_DATA_INDEX, $value);
+        get => $this->getData(self::ILS_INDEX);
+        set => $this->setData(self::ILS_INDEX, $value);
     }
 
     // INR
     public const string INR = 'INR';
-    protected const string INR_DATA_NAME = 'INR';
-    protected const int INR_DATA_INDEX = 13;
+    protected const int INR_INDEX = 13;
 
     public ?float $INR {
-        get => $this->getData(self::INR_DATA_INDEX);
-        set => $this->setData(self::INR_DATA_INDEX, $value);
+        get => $this->getData(self::INR_INDEX);
+        set => $this->setData(self::INR_INDEX, $value);
     }
 
     // ISK
     public const string ISK = 'ISK';
-    protected const string ISK_DATA_NAME = 'ISK';
-    protected const int ISK_DATA_INDEX = 14;
+    protected const int ISK_INDEX = 14;
 
     public ?float $ISK {
-        get => $this->getData(self::ISK_DATA_INDEX);
-        set => $this->setData(self::ISK_DATA_INDEX, $value);
+        get => $this->getData(self::ISK_INDEX);
+        set => $this->setData(self::ISK_INDEX, $value);
     }
 
     // JPY
     public const string JPY = 'JPY';
-    protected const string JPY_DATA_NAME = 'JPY';
-    protected const int JPY_DATA_INDEX = 15;
+    protected const int JPY_INDEX = 15;
 
     public ?float $JPY {
-        get => $this->getData(self::JPY_DATA_INDEX);
-        set => $this->setData(self::JPY_DATA_INDEX, $value);
+        get => $this->getData(self::JPY_INDEX);
+        set => $this->setData(self::JPY_INDEX, $value);
     }
 
     // KRW
     public const string KRW = 'KRW';
-    protected const string KRW_DATA_NAME = 'KRW';
-    protected const int KRW_DATA_INDEX = 16;
+    protected const int KRW_INDEX = 16;
 
     public ?float $KRW {
-        get => $this->getData(self::KRW_DATA_INDEX);
-        set => $this->setData(self::KRW_DATA_INDEX, $value);
+        get => $this->getData(self::KRW_INDEX);
+        set => $this->setData(self::KRW_INDEX, $value);
     }
 
     // MXN
     public const string MXN = 'MXN';
-    protected const string MXN_DATA_NAME = 'MXN';
-    protected const int MXN_DATA_INDEX = 17;
+    protected const int MXN_INDEX = 17;
 
     public ?float $MXN {
-        get => $this->getData(self::MXN_DATA_INDEX);
-        set => $this->setData(self::MXN_DATA_INDEX, $value);
+        get => $this->getData(self::MXN_INDEX);
+        set => $this->setData(self::MXN_INDEX, $value);
     }
 
     // MYR
     public const string MYR = 'MYR';
-    protected const string MYR_DATA_NAME = 'MYR';
-    protected const int MYR_DATA_INDEX = 18;
+    protected const int MYR_INDEX = 18;
 
     public ?float $MYR {
-        get => $this->getData(self::MYR_DATA_INDEX);
-        set => $this->setData(self::MYR_DATA_INDEX, $value);
+        get => $this->getData(self::MYR_INDEX);
+        set => $this->setData(self::MYR_INDEX, $value);
     }
 
     // NOK
     public const string NOK = 'NOK';
-    protected const string NOK_DATA_NAME = 'NOK';
-    protected const int NOK_DATA_INDEX = 19;
+    protected const int NOK_INDEX = 19;
 
     public ?float $NOK {
-        get => $this->getData(self::NOK_DATA_INDEX);
-        set => $this->setData(self::NOK_DATA_INDEX, $value);
+        get => $this->getData(self::NOK_INDEX);
+        set => $this->setData(self::NOK_INDEX, $value);
     }
 
     // NZD
     public const string NZD = 'NZD';
-    protected const string NZD_DATA_NAME = 'NZD';
-    protected const int NZD_DATA_INDEX = 20;
+    protected const int NZD_INDEX = 20;
 
     public ?float $NZD {
-        get => $this->getData(self::NZD_DATA_INDEX);
-        set => $this->setData(self::NZD_DATA_INDEX, $value);
+        get => $this->getData(self::NZD_INDEX);
+        set => $this->setData(self::NZD_INDEX, $value);
     }
 
     // PHP
     public const string PHP = 'PHP';
-    protected const string PHP_DATA_NAME = 'PHP';
-    protected const int PHP_DATA_INDEX = 21;
+    protected const int PHP_INDEX = 21;
 
     public ?float $PHP {
-        get => $this->getData(self::PHP_DATA_INDEX);
-        set => $this->setData(self::PHP_DATA_INDEX, $value);
+        get => $this->getData(self::PHP_INDEX);
+        set => $this->setData(self::PHP_INDEX, $value);
     }
 
     // PLN
     public const string PLN = 'PLN';
-    protected const string PLN_DATA_NAME = 'PLN';
-    protected const int PLN_DATA_INDEX = 22;
+    protected const int PLN_INDEX = 22;
 
     public ?float $PLN {
-        get => $this->getData(self::PLN_DATA_INDEX);
-        set => $this->setData(self::PLN_DATA_INDEX, $value);
+        get => $this->getData(self::PLN_INDEX);
+        set => $this->setData(self::PLN_INDEX, $value);
     }
 
     // RON
     public const string RON = 'RON';
-    protected const string RON_DATA_NAME = 'RON';
-    protected const int RON_DATA_INDEX = 23;
+    protected const int RON_INDEX = 23;
 
     public ?float $RON {
-        get => $this->getData(self::RON_DATA_INDEX);
-        set => $this->setData(self::RON_DATA_INDEX, $value);
+        get => $this->getData(self::RON_INDEX);
+        set => $this->setData(self::RON_INDEX, $value);
     }
 
     // SEK
     public const string SEK = 'SEK';
-    protected const string SEK_DATA_NAME = 'SEK';
-    protected const int SEK_DATA_INDEX = 24;
+    protected const int SEK_INDEX = 24;
 
     public ?float $SEK {
-        get => $this->getData(self::SEK_DATA_INDEX);
-        set => $this->setData(self::SEK_DATA_INDEX, $value);
+        get => $this->getData(self::SEK_INDEX);
+        set => $this->setData(self::SEK_INDEX, $value);
     }
 
     // SGD
     public const string SGD = 'SGD';
-    protected const string SGD_DATA_NAME = 'SGD';
-    protected const int SGD_DATA_INDEX = 25;
+    protected const int SGD_INDEX = 25;
 
     public ?float $SGD {
-        get => $this->getData(self::SGD_DATA_INDEX);
-        set => $this->setData(self::SGD_DATA_INDEX, $value);
+        get => $this->getData(self::SGD_INDEX);
+        set => $this->setData(self::SGD_INDEX, $value);
     }
 
     // THB
     public const string THB = 'THB';
-    protected const string THB_DATA_NAME = 'THB';
-    protected const int THB_DATA_INDEX = 26;
+    protected const int THB_INDEX = 26;
 
     public ?float $THB {
-        get => $this->getData(self::THB_DATA_INDEX);
-        set => $this->setData(self::THB_DATA_INDEX, $value);
+        get => $this->getData(self::THB_INDEX);
+        set => $this->setData(self::THB_INDEX, $value);
     }
 
     // TRY
     public const string TRY = 'TRY';
-    protected const string TRY_DATA_NAME = 'TRY';
-    protected const int TRY_DATA_INDEX = 27;
+    protected const int TRY_INDEX = 27;
 
     public ?float $TRY {
-        get => $this->getData(self::TRY_DATA_INDEX);
-        set => $this->setData(self::TRY_DATA_INDEX, $value);
+        get => $this->getData(self::TRY_INDEX);
+        set => $this->setData(self::TRY_INDEX, $value);
     }
 
     // USD
     public const string USD = 'USD';
-    protected const string USD_DATA_NAME = 'USD';
-    protected const int USD_DATA_INDEX = 28;
+    protected const int USD_INDEX = 28;
 
     public ?float $USD {
-        get => $this->getData(self::USD_DATA_INDEX);
-        set => $this->setData(self::USD_DATA_INDEX, $value);
+        get => $this->getData(self::USD_INDEX);
+        set => $this->setData(self::USD_INDEX, $value);
     }
 
     // ZAR
     public const string ZAR = 'ZAR';
-    protected const string ZAR_DATA_NAME = 'ZAR';
-    protected const int ZAR_DATA_INDEX = 29;
+    protected const int ZAR_INDEX = 29;
 
     public ?float $ZAR {
-        get => $this->getData(self::ZAR_DATA_INDEX);
-        set => $this->setData(self::ZAR_DATA_INDEX, $value);
+        get => $this->getData(self::ZAR_INDEX);
+        set => $this->setData(self::ZAR_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/PriceTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/PriceTransfer.php
@@ -20,27 +20,25 @@ final class PriceTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::CURRENCY => self::CURRENCY_DATA_NAME,
-        self::VALUE => self::VALUE_DATA_NAME,
+        self::CURRENCY_INDEX => self::CURRENCY,
+        self::VALUE_INDEX => self::VALUE,
     ];
 
     // currency
     public const string CURRENCY = 'currency';
-    protected const string CURRENCY_DATA_NAME = 'CURRENCY';
-    protected const int CURRENCY_DATA_INDEX = 0;
+    protected const int CURRENCY_INDEX = 0;
 
     public ?string $currency {
-        get => $this->getData(self::CURRENCY_DATA_INDEX);
-        set => $this->setData(self::CURRENCY_DATA_INDEX, $value);
+        get => $this->getData(self::CURRENCY_INDEX);
+        set => $this->setData(self::CURRENCY_INDEX, $value);
     }
 
     // value
     public const string VALUE = 'value';
-    protected const string VALUE_DATA_NAME = 'VALUE';
-    protected const int VALUE_DATA_INDEX = 1;
+    protected const int VALUE_INDEX = 1;
 
     public ?string $value {
-        get => $this->getData(self::VALUE_DATA_INDEX);
-        set => $this->setData(self::VALUE_DATA_INDEX, $value);
+        get => $this->getData(self::VALUE_INDEX);
+        set => $this->setData(self::VALUE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/ProductTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/ProductTransfer.php
@@ -24,284 +24,259 @@ final class ProductTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 25;
 
     protected const array META_DATA = [
-        self::AGE_GROUP => self::AGE_GROUP_DATA_NAME,
-        self::AVAILABILITY => self::AVAILABILITY_DATA_NAME,
-        self::AVAILABILITY_DATE => self::AVAILABILITY_DATE_DATA_NAME,
-        self::BRAND => self::BRAND_DATA_NAME,
-        self::CHANNEL => self::CHANNEL_DATA_NAME,
-        self::COLOR => self::COLOR_DATA_NAME,
-        self::CONDITION => self::CONDITION_DATA_NAME,
-        self::CONTENT_LANGUAGE => self::CONTENT_LANGUAGE_DATA_NAME,
-        self::DESCRIPTION => self::DESCRIPTION_DATA_NAME,
-        self::FEED_LABEL => self::FEED_LABEL_DATA_NAME,
-        self::GENDER => self::GENDER_DATA_NAME,
-        self::GOOGLE_PRODUCT_CATEGORY => self::GOOGLE_PRODUCT_CATEGORY_DATA_NAME,
-        self::GTIN => self::GTIN_DATA_NAME,
-        self::ID => self::ID_DATA_NAME,
-        self::IMAGE_LINK => self::IMAGE_LINK_DATA_NAME,
-        self::ITEM_GROUP_ID => self::ITEM_GROUP_ID_DATA_NAME,
-        self::KIND => self::KIND_DATA_NAME,
-        self::LINK => self::LINK_DATA_NAME,
-        self::MPN => self::MPN_DATA_NAME,
-        self::OFFER_ID => self::OFFER_ID_DATA_NAME,
-        self::PRICE => self::PRICE_DATA_NAME,
-        self::SIZES => self::SIZES_DATA_NAME,
-        self::SOURCE => self::SOURCE_DATA_NAME,
-        self::TARGET_COUNTRY => self::TARGET_COUNTRY_DATA_NAME,
-        self::TITLE => self::TITLE_DATA_NAME,
+        self::AGE_GROUP_INDEX => self::AGE_GROUP,
+        self::AVAILABILITY_INDEX => self::AVAILABILITY,
+        self::AVAILABILITY_DATE_INDEX => self::AVAILABILITY_DATE,
+        self::BRAND_INDEX => self::BRAND,
+        self::CHANNEL_INDEX => self::CHANNEL,
+        self::COLOR_INDEX => self::COLOR,
+        self::CONDITION_INDEX => self::CONDITION,
+        self::CONTENT_LANGUAGE_INDEX => self::CONTENT_LANGUAGE,
+        self::DESCRIPTION_INDEX => self::DESCRIPTION,
+        self::FEED_LABEL_INDEX => self::FEED_LABEL,
+        self::GENDER_INDEX => self::GENDER,
+        self::GOOGLE_PRODUCT_CATEGORY_INDEX => self::GOOGLE_PRODUCT_CATEGORY,
+        self::GTIN_INDEX => self::GTIN,
+        self::ID_INDEX => self::ID,
+        self::IMAGE_LINK_INDEX => self::IMAGE_LINK,
+        self::ITEM_GROUP_ID_INDEX => self::ITEM_GROUP_ID,
+        self::KIND_INDEX => self::KIND,
+        self::LINK_INDEX => self::LINK,
+        self::MPN_INDEX => self::MPN,
+        self::OFFER_ID_INDEX => self::OFFER_ID,
+        self::PRICE_INDEX => self::PRICE,
+        self::SIZES_INDEX => self::SIZES,
+        self::SOURCE_INDEX => self::SOURCE,
+        self::TARGET_COUNTRY_INDEX => self::TARGET_COUNTRY,
+        self::TITLE_INDEX => self::TITLE,
     ];
 
     // ageGroup
     public const string AGE_GROUP = 'ageGroup';
-    protected const string AGE_GROUP_DATA_NAME = 'AGE_GROUP';
-    protected const int AGE_GROUP_DATA_INDEX = 0;
+    protected const int AGE_GROUP_INDEX = 0;
 
     public ?string $ageGroup {
-        get => $this->getData(self::AGE_GROUP_DATA_INDEX);
-        set => $this->setData(self::AGE_GROUP_DATA_INDEX, $value);
+        get => $this->getData(self::AGE_GROUP_INDEX);
+        set => $this->setData(self::AGE_GROUP_INDEX, $value);
     }
 
     // availability
     public const string AVAILABILITY = 'availability';
-    protected const string AVAILABILITY_DATA_NAME = 'AVAILABILITY';
-    protected const int AVAILABILITY_DATA_INDEX = 1;
+    protected const int AVAILABILITY_INDEX = 1;
 
     public ?string $availability {
-        get => $this->getData(self::AVAILABILITY_DATA_INDEX);
-        set => $this->setData(self::AVAILABILITY_DATA_INDEX, $value);
+        get => $this->getData(self::AVAILABILITY_INDEX);
+        set => $this->setData(self::AVAILABILITY_INDEX, $value);
     }
 
     // availabilityDate
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string AVAILABILITY_DATE = 'availabilityDate';
-    protected const string AVAILABILITY_DATE_DATA_NAME = 'AVAILABILITY_DATE';
-    protected const int AVAILABILITY_DATE_DATA_INDEX = 2;
+    protected const int AVAILABILITY_DATE_INDEX = 2;
 
     public ?DateTime $availabilityDate {
-        get => $this->getData(self::AVAILABILITY_DATE_DATA_INDEX);
-        set => $this->setData(self::AVAILABILITY_DATE_DATA_INDEX, $value);
+        get => $this->getData(self::AVAILABILITY_DATE_INDEX);
+        set => $this->setData(self::AVAILABILITY_DATE_INDEX, $value);
     }
 
     // brand
     public const string BRAND = 'brand';
-    protected const string BRAND_DATA_NAME = 'BRAND';
-    protected const int BRAND_DATA_INDEX = 3;
+    protected const int BRAND_INDEX = 3;
 
     public ?string $brand {
-        get => $this->getData(self::BRAND_DATA_INDEX);
-        set => $this->setData(self::BRAND_DATA_INDEX, $value);
+        get => $this->getData(self::BRAND_INDEX);
+        set => $this->setData(self::BRAND_INDEX, $value);
     }
 
     // channel
     public const string CHANNEL = 'channel';
-    protected const string CHANNEL_DATA_NAME = 'CHANNEL';
-    protected const int CHANNEL_DATA_INDEX = 4;
+    protected const int CHANNEL_INDEX = 4;
 
     public ?string $channel {
-        get => $this->getData(self::CHANNEL_DATA_INDEX);
-        set => $this->setData(self::CHANNEL_DATA_INDEX, $value);
+        get => $this->getData(self::CHANNEL_INDEX);
+        set => $this->setData(self::CHANNEL_INDEX, $value);
     }
 
     // color
     public const string COLOR = 'color';
-    protected const string COLOR_DATA_NAME = 'COLOR';
-    protected const int COLOR_DATA_INDEX = 5;
+    protected const int COLOR_INDEX = 5;
 
     public ?string $color {
-        get => $this->getData(self::COLOR_DATA_INDEX);
-        set => $this->setData(self::COLOR_DATA_INDEX, $value);
+        get => $this->getData(self::COLOR_INDEX);
+        set => $this->setData(self::COLOR_INDEX, $value);
     }
 
     // condition
     public const string CONDITION = 'condition';
-    protected const string CONDITION_DATA_NAME = 'CONDITION';
-    protected const int CONDITION_DATA_INDEX = 6;
+    protected const int CONDITION_INDEX = 6;
 
     public ?string $condition {
-        get => $this->getData(self::CONDITION_DATA_INDEX);
-        set => $this->setData(self::CONDITION_DATA_INDEX, $value);
+        get => $this->getData(self::CONDITION_INDEX);
+        set => $this->setData(self::CONDITION_INDEX, $value);
     }
 
     // contentLanguage
     public const string CONTENT_LANGUAGE = 'contentLanguage';
-    protected const string CONTENT_LANGUAGE_DATA_NAME = 'CONTENT_LANGUAGE';
-    protected const int CONTENT_LANGUAGE_DATA_INDEX = 7;
+    protected const int CONTENT_LANGUAGE_INDEX = 7;
 
     public ?string $contentLanguage {
-        get => $this->getData(self::CONTENT_LANGUAGE_DATA_INDEX);
-        set => $this->setData(self::CONTENT_LANGUAGE_DATA_INDEX, $value);
+        get => $this->getData(self::CONTENT_LANGUAGE_INDEX);
+        set => $this->setData(self::CONTENT_LANGUAGE_INDEX, $value);
     }
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const string DESCRIPTION_DATA_NAME = 'DESCRIPTION';
-    protected const int DESCRIPTION_DATA_INDEX = 8;
+    protected const int DESCRIPTION_INDEX = 8;
 
     public ?string $description {
-        get => $this->getData(self::DESCRIPTION_DATA_INDEX);
-        set => $this->setData(self::DESCRIPTION_DATA_INDEX, $value);
+        get => $this->getData(self::DESCRIPTION_INDEX);
+        set => $this->setData(self::DESCRIPTION_INDEX, $value);
     }
 
     // feedLabel
     public const string FEED_LABEL = 'feedLabel';
-    protected const string FEED_LABEL_DATA_NAME = 'FEED_LABEL';
-    protected const int FEED_LABEL_DATA_INDEX = 9;
+    protected const int FEED_LABEL_INDEX = 9;
 
     public ?string $feedLabel {
-        get => $this->getData(self::FEED_LABEL_DATA_INDEX);
-        set => $this->setData(self::FEED_LABEL_DATA_INDEX, $value);
+        get => $this->getData(self::FEED_LABEL_INDEX);
+        set => $this->setData(self::FEED_LABEL_INDEX, $value);
     }
 
     // gender
     public const string GENDER = 'gender';
-    protected const string GENDER_DATA_NAME = 'GENDER';
-    protected const int GENDER_DATA_INDEX = 10;
+    protected const int GENDER_INDEX = 10;
 
     public ?string $gender {
-        get => $this->getData(self::GENDER_DATA_INDEX);
-        set => $this->setData(self::GENDER_DATA_INDEX, $value);
+        get => $this->getData(self::GENDER_INDEX);
+        set => $this->setData(self::GENDER_INDEX, $value);
     }
 
     // googleProductCategory
     public const string GOOGLE_PRODUCT_CATEGORY = 'googleProductCategory';
-    protected const string GOOGLE_PRODUCT_CATEGORY_DATA_NAME = 'GOOGLE_PRODUCT_CATEGORY';
-    protected const int GOOGLE_PRODUCT_CATEGORY_DATA_INDEX = 11;
+    protected const int GOOGLE_PRODUCT_CATEGORY_INDEX = 11;
 
     public ?string $googleProductCategory {
-        get => $this->getData(self::GOOGLE_PRODUCT_CATEGORY_DATA_INDEX);
-        set => $this->setData(self::GOOGLE_PRODUCT_CATEGORY_DATA_INDEX, $value);
+        get => $this->getData(self::GOOGLE_PRODUCT_CATEGORY_INDEX);
+        set => $this->setData(self::GOOGLE_PRODUCT_CATEGORY_INDEX, $value);
     }
 
     // gtin
     public const string GTIN = 'gtin';
-    protected const string GTIN_DATA_NAME = 'GTIN';
-    protected const int GTIN_DATA_INDEX = 12;
+    protected const int GTIN_INDEX = 12;
 
     public ?string $gtin {
-        get => $this->getData(self::GTIN_DATA_INDEX);
-        set => $this->setData(self::GTIN_DATA_INDEX, $value);
+        get => $this->getData(self::GTIN_INDEX);
+        set => $this->setData(self::GTIN_INDEX, $value);
     }
 
     // id
     public const string ID = 'id';
-    protected const string ID_DATA_NAME = 'ID';
-    protected const int ID_DATA_INDEX = 13;
+    protected const int ID_INDEX = 13;
 
     public ?string $id {
-        get => $this->getData(self::ID_DATA_INDEX);
-        set => $this->setData(self::ID_DATA_INDEX, $value);
+        get => $this->getData(self::ID_INDEX);
+        set => $this->setData(self::ID_INDEX, $value);
     }
 
     // imageLink
     public const string IMAGE_LINK = 'imageLink';
-    protected const string IMAGE_LINK_DATA_NAME = 'IMAGE_LINK';
-    protected const int IMAGE_LINK_DATA_INDEX = 14;
+    protected const int IMAGE_LINK_INDEX = 14;
 
     public ?string $imageLink {
-        get => $this->getData(self::IMAGE_LINK_DATA_INDEX);
-        set => $this->setData(self::IMAGE_LINK_DATA_INDEX, $value);
+        get => $this->getData(self::IMAGE_LINK_INDEX);
+        set => $this->setData(self::IMAGE_LINK_INDEX, $value);
     }
 
     // itemGroupId
     public const string ITEM_GROUP_ID = 'itemGroupId';
-    protected const string ITEM_GROUP_ID_DATA_NAME = 'ITEM_GROUP_ID';
-    protected const int ITEM_GROUP_ID_DATA_INDEX = 15;
+    protected const int ITEM_GROUP_ID_INDEX = 15;
 
     public ?string $itemGroupId {
-        get => $this->getData(self::ITEM_GROUP_ID_DATA_INDEX);
-        set => $this->setData(self::ITEM_GROUP_ID_DATA_INDEX, $value);
+        get => $this->getData(self::ITEM_GROUP_ID_INDEX);
+        set => $this->setData(self::ITEM_GROUP_ID_INDEX, $value);
     }
 
     // kind
     public const string KIND = 'kind';
-    protected const string KIND_DATA_NAME = 'KIND';
-    protected const int KIND_DATA_INDEX = 16;
+    protected const int KIND_INDEX = 16;
 
     public ?string $kind {
-        get => $this->getData(self::KIND_DATA_INDEX);
-        set => $this->setData(self::KIND_DATA_INDEX, $value);
+        get => $this->getData(self::KIND_INDEX);
+        set => $this->setData(self::KIND_INDEX, $value);
     }
 
     // link
     public const string LINK = 'link';
-    protected const string LINK_DATA_NAME = 'LINK';
-    protected const int LINK_DATA_INDEX = 17;
+    protected const int LINK_INDEX = 17;
 
     public ?string $link {
-        get => $this->getData(self::LINK_DATA_INDEX);
-        set => $this->setData(self::LINK_DATA_INDEX, $value);
+        get => $this->getData(self::LINK_INDEX);
+        set => $this->setData(self::LINK_INDEX, $value);
     }
 
     // mpn
     public const string MPN = 'mpn';
-    protected const string MPN_DATA_NAME = 'MPN';
-    protected const int MPN_DATA_INDEX = 18;
+    protected const int MPN_INDEX = 18;
 
     public ?string $mpn {
-        get => $this->getData(self::MPN_DATA_INDEX);
-        set => $this->setData(self::MPN_DATA_INDEX, $value);
+        get => $this->getData(self::MPN_INDEX);
+        set => $this->setData(self::MPN_INDEX, $value);
     }
 
     // offerId
     public const string OFFER_ID = 'offerId';
-    protected const string OFFER_ID_DATA_NAME = 'OFFER_ID';
-    protected const int OFFER_ID_DATA_INDEX = 19;
+    protected const int OFFER_ID_INDEX = 19;
 
     public ?string $offerId {
-        get => $this->getData(self::OFFER_ID_DATA_INDEX);
-        set => $this->setData(self::OFFER_ID_DATA_INDEX, $value);
+        get => $this->getData(self::OFFER_ID_INDEX);
+        set => $this->setData(self::OFFER_ID_INDEX, $value);
     }
 
     // price
     #[PropertyTypeAttribute(PriceTransfer::class)]
     public const string PRICE = 'price';
-    protected const string PRICE_DATA_NAME = 'PRICE';
-    protected const int PRICE_DATA_INDEX = 20;
+    protected const int PRICE_INDEX = 20;
 
     public ?PriceTransfer $price {
-        get => $this->getData(self::PRICE_DATA_INDEX);
-        set => $this->setData(self::PRICE_DATA_INDEX, $value);
+        get => $this->getData(self::PRICE_INDEX);
+        set => $this->setData(self::PRICE_INDEX, $value);
     }
 
     // sizes
     #[ArrayPropertyTypeAttribute]
     public const string SIZES = 'sizes';
-    protected const string SIZES_DATA_NAME = 'SIZES';
-    protected const int SIZES_DATA_INDEX = 21;
+    protected const int SIZES_INDEX = 21;
 
     /** @var array<int|string,mixed> */
     public array $sizes {
-        get => $this->getData(self::SIZES_DATA_INDEX);
-        set => $this->setData(self::SIZES_DATA_INDEX, $value);
+        get => $this->getData(self::SIZES_INDEX);
+        set => $this->setData(self::SIZES_INDEX, $value);
     }
 
     // source
     public const string SOURCE = 'source';
-    protected const string SOURCE_DATA_NAME = 'SOURCE';
-    protected const int SOURCE_DATA_INDEX = 22;
+    protected const int SOURCE_INDEX = 22;
 
     public ?string $source {
-        get => $this->getData(self::SOURCE_DATA_INDEX);
-        set => $this->setData(self::SOURCE_DATA_INDEX, $value);
+        get => $this->getData(self::SOURCE_INDEX);
+        set => $this->setData(self::SOURCE_INDEX, $value);
     }
 
     // targetCountry
     public const string TARGET_COUNTRY = 'targetCountry';
-    protected const string TARGET_COUNTRY_DATA_NAME = 'TARGET_COUNTRY';
-    protected const int TARGET_COUNTRY_DATA_INDEX = 23;
+    protected const int TARGET_COUNTRY_INDEX = 23;
 
     public ?string $targetCountry {
-        get => $this->getData(self::TARGET_COUNTRY_DATA_INDEX);
-        set => $this->setData(self::TARGET_COUNTRY_DATA_INDEX, $value);
+        get => $this->getData(self::TARGET_COUNTRY_INDEX);
+        set => $this->setData(self::TARGET_COUNTRY_INDEX, $value);
     }
 
     // title
     public const string TITLE = 'title';
-    protected const string TITLE_DATA_NAME = 'TITLE';
-    protected const int TITLE_DATA_INDEX = 24;
+    protected const int TITLE_INDEX = 24;
 
     public ?string $title {
-        get => $this->getData(self::TITLE_DATA_INDEX);
-        set => $this->setData(self::TITLE_DATA_INDEX, $value);
+        get => $this->getData(self::TITLE_INDEX);
+        set => $this->setData(self::TITLE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/AsteroidTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/AsteroidTransfer.php
@@ -23,142 +23,130 @@ final class AsteroidTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 12;
 
     protected const array META_DATA = [
-        self::ABSOLUTE_MAGNITUDE_H => self::ABSOLUTE_MAGNITUDE_H_DATA_NAME,
-        self::CLOSE_APPROACH_DATA => self::CLOSE_APPROACH_DATA_DATA_NAME,
-        self::DESIGNATION => self::DESIGNATION_DATA_NAME,
-        self::ESTIMATED_DIAMETER => self::ESTIMATED_DIAMETER_DATA_NAME,
-        self::ID => self::ID_DATA_NAME,
-        self::IS_POTENTIALLY_HAZARDOUS_ASTEROID => self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_DATA_NAME,
-        self::IS_SENTRY_OBJECT => self::IS_SENTRY_OBJECT_DATA_NAME,
-        self::LINKS => self::LINKS_DATA_NAME,
-        self::NAME => self::NAME_DATA_NAME,
-        self::NASA_JPL_URL => self::NASA_JPL_URL_DATA_NAME,
-        self::NEO_REFERENCE_ID => self::NEO_REFERENCE_ID_DATA_NAME,
-        self::ORBITAL_DATA => self::ORBITAL_DATA_DATA_NAME,
+        self::ABSOLUTE_MAGNITUDE_H_INDEX => self::ABSOLUTE_MAGNITUDE_H,
+        self::CLOSE_APPROACH_DATA_INDEX => self::CLOSE_APPROACH_DATA,
+        self::DESIGNATION_INDEX => self::DESIGNATION,
+        self::ESTIMATED_DIAMETER_INDEX => self::ESTIMATED_DIAMETER,
+        self::ID_INDEX => self::ID,
+        self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX => self::IS_POTENTIALLY_HAZARDOUS_ASTEROID,
+        self::IS_SENTRY_OBJECT_INDEX => self::IS_SENTRY_OBJECT,
+        self::LINKS_INDEX => self::LINKS,
+        self::NAME_INDEX => self::NAME,
+        self::NASA_JPL_URL_INDEX => self::NASA_JPL_URL,
+        self::NEO_REFERENCE_ID_INDEX => self::NEO_REFERENCE_ID,
+        self::ORBITAL_DATA_INDEX => self::ORBITAL_DATA,
     ];
 
     // absolute_magnitude_h
     public const string ABSOLUTE_MAGNITUDE_H = 'absolute_magnitude_h';
-    protected const string ABSOLUTE_MAGNITUDE_H_DATA_NAME = 'ABSOLUTE_MAGNITUDE_H';
-    protected const int ABSOLUTE_MAGNITUDE_H_DATA_INDEX = 0;
+    protected const int ABSOLUTE_MAGNITUDE_H_INDEX = 0;
 
     public ?float $absolute_magnitude_h {
-        get => $this->getData(self::ABSOLUTE_MAGNITUDE_H_DATA_INDEX);
-        set => $this->setData(self::ABSOLUTE_MAGNITUDE_H_DATA_INDEX, $value);
+        get => $this->getData(self::ABSOLUTE_MAGNITUDE_H_INDEX);
+        set => $this->setData(self::ABSOLUTE_MAGNITUDE_H_INDEX, $value);
     }
 
     // close_approach_data
     #[CollectionPropertyTypeAttribute(CloseApproachDataTransfer::class)]
     public const string CLOSE_APPROACH_DATA = 'close_approach_data';
-    protected const string CLOSE_APPROACH_DATA_DATA_NAME = 'CLOSE_APPROACH_DATA';
-    protected const int CLOSE_APPROACH_DATA_DATA_INDEX = 1;
+    protected const int CLOSE_APPROACH_DATA_INDEX = 1;
 
     /** @var \ArrayObject<int,CloseApproachDataTransfer> */
     public ArrayObject $close_approach_data {
-        get => $this->getData(self::CLOSE_APPROACH_DATA_DATA_INDEX);
-        set => $this->setData(self::CLOSE_APPROACH_DATA_DATA_INDEX, $value);
+        get => $this->getData(self::CLOSE_APPROACH_DATA_INDEX);
+        set => $this->setData(self::CLOSE_APPROACH_DATA_INDEX, $value);
     }
 
     // designation
     public const string DESIGNATION = 'designation';
-    protected const string DESIGNATION_DATA_NAME = 'DESIGNATION';
-    protected const int DESIGNATION_DATA_INDEX = 2;
+    protected const int DESIGNATION_INDEX = 2;
 
     public ?string $designation {
-        get => $this->getData(self::DESIGNATION_DATA_INDEX);
-        set => $this->setData(self::DESIGNATION_DATA_INDEX, $value);
+        get => $this->getData(self::DESIGNATION_INDEX);
+        set => $this->setData(self::DESIGNATION_INDEX, $value);
     }
 
     // estimated_diameter
     #[PropertyTypeAttribute(EstimatedDiameterTransfer::class)]
     public const string ESTIMATED_DIAMETER = 'estimated_diameter';
-    protected const string ESTIMATED_DIAMETER_DATA_NAME = 'ESTIMATED_DIAMETER';
-    protected const int ESTIMATED_DIAMETER_DATA_INDEX = 3;
+    protected const int ESTIMATED_DIAMETER_INDEX = 3;
 
     public ?EstimatedDiameterTransfer $estimated_diameter {
-        get => $this->getData(self::ESTIMATED_DIAMETER_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_INDEX, $value);
     }
 
     // id
     public const string ID = 'id';
-    protected const string ID_DATA_NAME = 'ID';
-    protected const int ID_DATA_INDEX = 4;
+    protected const int ID_INDEX = 4;
 
     public ?string $id {
-        get => $this->getData(self::ID_DATA_INDEX);
-        set => $this->setData(self::ID_DATA_INDEX, $value);
+        get => $this->getData(self::ID_INDEX);
+        set => $this->setData(self::ID_INDEX, $value);
     }
 
     // is_potentially_hazardous_asteroid
     public const string IS_POTENTIALLY_HAZARDOUS_ASTEROID = 'is_potentially_hazardous_asteroid';
-    protected const string IS_POTENTIALLY_HAZARDOUS_ASTEROID_DATA_NAME = 'IS_POTENTIALLY_HAZARDOUS_ASTEROID';
-    protected const int IS_POTENTIALLY_HAZARDOUS_ASTEROID_DATA_INDEX = 5;
+    protected const int IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX = 5;
 
     public ?bool $is_potentially_hazardous_asteroid {
-        get => $this->getData(self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_DATA_INDEX);
-        set => $this->setData(self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_DATA_INDEX, $value);
+        get => $this->getData(self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX);
+        set => $this->setData(self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX, $value);
     }
 
     // is_sentry_object
     public const string IS_SENTRY_OBJECT = 'is_sentry_object';
-    protected const string IS_SENTRY_OBJECT_DATA_NAME = 'IS_SENTRY_OBJECT';
-    protected const int IS_SENTRY_OBJECT_DATA_INDEX = 6;
+    protected const int IS_SENTRY_OBJECT_INDEX = 6;
 
     public ?bool $is_sentry_object {
-        get => $this->getData(self::IS_SENTRY_OBJECT_DATA_INDEX);
-        set => $this->setData(self::IS_SENTRY_OBJECT_DATA_INDEX, $value);
+        get => $this->getData(self::IS_SENTRY_OBJECT_INDEX);
+        set => $this->setData(self::IS_SENTRY_OBJECT_INDEX, $value);
     }
 
     // links
     #[PropertyTypeAttribute(LinksTransfer::class)]
     public const string LINKS = 'links';
-    protected const string LINKS_DATA_NAME = 'LINKS';
-    protected const int LINKS_DATA_INDEX = 7;
+    protected const int LINKS_INDEX = 7;
 
     public ?LinksTransfer $links {
-        get => $this->getData(self::LINKS_DATA_INDEX);
-        set => $this->setData(self::LINKS_DATA_INDEX, $value);
+        get => $this->getData(self::LINKS_INDEX);
+        set => $this->setData(self::LINKS_INDEX, $value);
     }
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 8;
+    protected const int NAME_INDEX = 8;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 
     // nasa_jpl_url
     public const string NASA_JPL_URL = 'nasa_jpl_url';
-    protected const string NASA_JPL_URL_DATA_NAME = 'NASA_JPL_URL';
-    protected const int NASA_JPL_URL_DATA_INDEX = 9;
+    protected const int NASA_JPL_URL_INDEX = 9;
 
     public ?string $nasa_jpl_url {
-        get => $this->getData(self::NASA_JPL_URL_DATA_INDEX);
-        set => $this->setData(self::NASA_JPL_URL_DATA_INDEX, $value);
+        get => $this->getData(self::NASA_JPL_URL_INDEX);
+        set => $this->setData(self::NASA_JPL_URL_INDEX, $value);
     }
 
     // neo_reference_id
     public const string NEO_REFERENCE_ID = 'neo_reference_id';
-    protected const string NEO_REFERENCE_ID_DATA_NAME = 'NEO_REFERENCE_ID';
-    protected const int NEO_REFERENCE_ID_DATA_INDEX = 10;
+    protected const int NEO_REFERENCE_ID_INDEX = 10;
 
     public ?string $neo_reference_id {
-        get => $this->getData(self::NEO_REFERENCE_ID_DATA_INDEX);
-        set => $this->setData(self::NEO_REFERENCE_ID_DATA_INDEX, $value);
+        get => $this->getData(self::NEO_REFERENCE_ID_INDEX);
+        set => $this->setData(self::NEO_REFERENCE_ID_INDEX, $value);
     }
 
     // orbital_data
     #[PropertyTypeAttribute(OrbitalDataTransfer::class)]
     public const string ORBITAL_DATA = 'orbital_data';
-    protected const string ORBITAL_DATA_DATA_NAME = 'ORBITAL_DATA';
-    protected const int ORBITAL_DATA_DATA_INDEX = 11;
+    protected const int ORBITAL_DATA_INDEX = 11;
 
     public ?OrbitalDataTransfer $orbital_data {
-        get => $this->getData(self::ORBITAL_DATA_DATA_INDEX);
-        set => $this->setData(self::ORBITAL_DATA_DATA_INDEX, $value);
+        get => $this->getData(self::ORBITAL_DATA_INDEX);
+        set => $this->setData(self::ORBITAL_DATA_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/CloseApproachDataTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/CloseApproachDataTransfer.php
@@ -21,73 +21,67 @@ final class CloseApproachDataTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 6;
 
     protected const array META_DATA = [
-        self::CLOSE_APPROACH_DATE => self::CLOSE_APPROACH_DATE_DATA_NAME,
-        self::CLOSE_APPROACH_DATE_FULL => self::CLOSE_APPROACH_DATE_FULL_DATA_NAME,
-        self::EPOCH_DATE_CLOSE_APPROACH => self::EPOCH_DATE_CLOSE_APPROACH_DATA_NAME,
-        self::MISS_DISTANCE => self::MISS_DISTANCE_DATA_NAME,
-        self::ORBITING_BODY => self::ORBITING_BODY_DATA_NAME,
-        self::RELATIVE_VELOCITY => self::RELATIVE_VELOCITY_DATA_NAME,
+        self::CLOSE_APPROACH_DATE_INDEX => self::CLOSE_APPROACH_DATE,
+        self::CLOSE_APPROACH_DATE_FULL_INDEX => self::CLOSE_APPROACH_DATE_FULL,
+        self::EPOCH_DATE_CLOSE_APPROACH_INDEX => self::EPOCH_DATE_CLOSE_APPROACH,
+        self::MISS_DISTANCE_INDEX => self::MISS_DISTANCE,
+        self::ORBITING_BODY_INDEX => self::ORBITING_BODY,
+        self::RELATIVE_VELOCITY_INDEX => self::RELATIVE_VELOCITY,
     ];
 
     // close_approach_date
     public const string CLOSE_APPROACH_DATE = 'close_approach_date';
-    protected const string CLOSE_APPROACH_DATE_DATA_NAME = 'CLOSE_APPROACH_DATE';
-    protected const int CLOSE_APPROACH_DATE_DATA_INDEX = 0;
+    protected const int CLOSE_APPROACH_DATE_INDEX = 0;
 
     public ?string $close_approach_date {
-        get => $this->getData(self::CLOSE_APPROACH_DATE_DATA_INDEX);
-        set => $this->setData(self::CLOSE_APPROACH_DATE_DATA_INDEX, $value);
+        get => $this->getData(self::CLOSE_APPROACH_DATE_INDEX);
+        set => $this->setData(self::CLOSE_APPROACH_DATE_INDEX, $value);
     }
 
     // close_approach_date_full
     public const string CLOSE_APPROACH_DATE_FULL = 'close_approach_date_full';
-    protected const string CLOSE_APPROACH_DATE_FULL_DATA_NAME = 'CLOSE_APPROACH_DATE_FULL';
-    protected const int CLOSE_APPROACH_DATE_FULL_DATA_INDEX = 1;
+    protected const int CLOSE_APPROACH_DATE_FULL_INDEX = 1;
 
     public ?string $close_approach_date_full {
-        get => $this->getData(self::CLOSE_APPROACH_DATE_FULL_DATA_INDEX);
-        set => $this->setData(self::CLOSE_APPROACH_DATE_FULL_DATA_INDEX, $value);
+        get => $this->getData(self::CLOSE_APPROACH_DATE_FULL_INDEX);
+        set => $this->setData(self::CLOSE_APPROACH_DATE_FULL_INDEX, $value);
     }
 
     // epoch_date_close_approach
     public const string EPOCH_DATE_CLOSE_APPROACH = 'epoch_date_close_approach';
-    protected const string EPOCH_DATE_CLOSE_APPROACH_DATA_NAME = 'EPOCH_DATE_CLOSE_APPROACH';
-    protected const int EPOCH_DATE_CLOSE_APPROACH_DATA_INDEX = 2;
+    protected const int EPOCH_DATE_CLOSE_APPROACH_INDEX = 2;
 
     public ?int $epoch_date_close_approach {
-        get => $this->getData(self::EPOCH_DATE_CLOSE_APPROACH_DATA_INDEX);
-        set => $this->setData(self::EPOCH_DATE_CLOSE_APPROACH_DATA_INDEX, $value);
+        get => $this->getData(self::EPOCH_DATE_CLOSE_APPROACH_INDEX);
+        set => $this->setData(self::EPOCH_DATE_CLOSE_APPROACH_INDEX, $value);
     }
 
     // miss_distance
     #[PropertyTypeAttribute(MissDistanceTransfer::class)]
     public const string MISS_DISTANCE = 'miss_distance';
-    protected const string MISS_DISTANCE_DATA_NAME = 'MISS_DISTANCE';
-    protected const int MISS_DISTANCE_DATA_INDEX = 3;
+    protected const int MISS_DISTANCE_INDEX = 3;
 
     public ?MissDistanceTransfer $miss_distance {
-        get => $this->getData(self::MISS_DISTANCE_DATA_INDEX);
-        set => $this->setData(self::MISS_DISTANCE_DATA_INDEX, $value);
+        get => $this->getData(self::MISS_DISTANCE_INDEX);
+        set => $this->setData(self::MISS_DISTANCE_INDEX, $value);
     }
 
     // orbiting_body
     public const string ORBITING_BODY = 'orbiting_body';
-    protected const string ORBITING_BODY_DATA_NAME = 'ORBITING_BODY';
-    protected const int ORBITING_BODY_DATA_INDEX = 4;
+    protected const int ORBITING_BODY_INDEX = 4;
 
     public ?string $orbiting_body {
-        get => $this->getData(self::ORBITING_BODY_DATA_INDEX);
-        set => $this->setData(self::ORBITING_BODY_DATA_INDEX, $value);
+        get => $this->getData(self::ORBITING_BODY_INDEX);
+        set => $this->setData(self::ORBITING_BODY_INDEX, $value);
     }
 
     // relative_velocity
     #[PropertyTypeAttribute(RelativeVelocityTransfer::class)]
     public const string RELATIVE_VELOCITY = 'relative_velocity';
-    protected const string RELATIVE_VELOCITY_DATA_NAME = 'RELATIVE_VELOCITY';
-    protected const int RELATIVE_VELOCITY_DATA_INDEX = 5;
+    protected const int RELATIVE_VELOCITY_INDEX = 5;
 
     public ?RelativeVelocityTransfer $relative_velocity {
-        get => $this->getData(self::RELATIVE_VELOCITY_DATA_INDEX);
-        set => $this->setData(self::RELATIVE_VELOCITY_DATA_INDEX, $value);
+        get => $this->getData(self::RELATIVE_VELOCITY_INDEX);
+        set => $this->setData(self::RELATIVE_VELOCITY_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/EstimatedDiameterTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/EstimatedDiameterTransfer.php
@@ -21,53 +21,49 @@ final class EstimatedDiameterTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::FEET => self::FEET_DATA_NAME,
-        self::KILOMETERS => self::KILOMETERS_DATA_NAME,
-        self::METERS => self::METERS_DATA_NAME,
-        self::MILES => self::MILES_DATA_NAME,
+        self::FEET_INDEX => self::FEET,
+        self::KILOMETERS_INDEX => self::KILOMETERS,
+        self::METERS_INDEX => self::METERS,
+        self::MILES_INDEX => self::MILES,
     ];
 
     // feet
     #[PropertyTypeAttribute(FeetTransfer::class)]
     public const string FEET = 'feet';
-    protected const string FEET_DATA_NAME = 'FEET';
-    protected const int FEET_DATA_INDEX = 0;
+    protected const int FEET_INDEX = 0;
 
     public ?FeetTransfer $feet {
-        get => $this->getData(self::FEET_DATA_INDEX);
-        set => $this->setData(self::FEET_DATA_INDEX, $value);
+        get => $this->getData(self::FEET_INDEX);
+        set => $this->setData(self::FEET_INDEX, $value);
     }
 
     // kilometers
     #[PropertyTypeAttribute(KilometersTransfer::class)]
     public const string KILOMETERS = 'kilometers';
-    protected const string KILOMETERS_DATA_NAME = 'KILOMETERS';
-    protected const int KILOMETERS_DATA_INDEX = 1;
+    protected const int KILOMETERS_INDEX = 1;
 
     public ?KilometersTransfer $kilometers {
-        get => $this->getData(self::KILOMETERS_DATA_INDEX);
-        set => $this->setData(self::KILOMETERS_DATA_INDEX, $value);
+        get => $this->getData(self::KILOMETERS_INDEX);
+        set => $this->setData(self::KILOMETERS_INDEX, $value);
     }
 
     // meters
     #[PropertyTypeAttribute(MetersTransfer::class)]
     public const string METERS = 'meters';
-    protected const string METERS_DATA_NAME = 'METERS';
-    protected const int METERS_DATA_INDEX = 2;
+    protected const int METERS_INDEX = 2;
 
     public ?MetersTransfer $meters {
-        get => $this->getData(self::METERS_DATA_INDEX);
-        set => $this->setData(self::METERS_DATA_INDEX, $value);
+        get => $this->getData(self::METERS_INDEX);
+        set => $this->setData(self::METERS_INDEX, $value);
     }
 
     // miles
     #[PropertyTypeAttribute(MilesTransfer::class)]
     public const string MILES = 'miles';
-    protected const string MILES_DATA_NAME = 'MILES';
-    protected const int MILES_DATA_INDEX = 3;
+    protected const int MILES_INDEX = 3;
 
     public ?MilesTransfer $miles {
-        get => $this->getData(self::MILES_DATA_INDEX);
-        set => $this->setData(self::MILES_DATA_INDEX, $value);
+        get => $this->getData(self::MILES_INDEX);
+        set => $this->setData(self::MILES_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/FeetTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/FeetTransfer.php
@@ -20,27 +20,25 @@ final class FeetTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ESTIMATED_DIAMETER_MAX => self::ESTIMATED_DIAMETER_MAX_DATA_NAME,
-        self::ESTIMATED_DIAMETER_MIN => self::ESTIMATED_DIAMETER_MIN_DATA_NAME,
+        self::ESTIMATED_DIAMETER_MAX_INDEX => self::ESTIMATED_DIAMETER_MAX,
+        self::ESTIMATED_DIAMETER_MIN_INDEX => self::ESTIMATED_DIAMETER_MIN,
     ];
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const string ESTIMATED_DIAMETER_MAX_DATA_NAME = 'ESTIMATED_DIAMETER_MAX';
-    protected const int ESTIMATED_DIAMETER_MAX_DATA_INDEX = 0;
+    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_INDEX, $value);
     }
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const string ESTIMATED_DIAMETER_MIN_DATA_NAME = 'ESTIMATED_DIAMETER_MIN';
-    protected const int ESTIMATED_DIAMETER_MIN_DATA_INDEX = 1;
+    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/KilometersTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/KilometersTransfer.php
@@ -20,27 +20,25 @@ final class KilometersTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ESTIMATED_DIAMETER_MAX => self::ESTIMATED_DIAMETER_MAX_DATA_NAME,
-        self::ESTIMATED_DIAMETER_MIN => self::ESTIMATED_DIAMETER_MIN_DATA_NAME,
+        self::ESTIMATED_DIAMETER_MAX_INDEX => self::ESTIMATED_DIAMETER_MAX,
+        self::ESTIMATED_DIAMETER_MIN_INDEX => self::ESTIMATED_DIAMETER_MIN,
     ];
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const string ESTIMATED_DIAMETER_MAX_DATA_NAME = 'ESTIMATED_DIAMETER_MAX';
-    protected const int ESTIMATED_DIAMETER_MAX_DATA_INDEX = 0;
+    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_INDEX, $value);
     }
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const string ESTIMATED_DIAMETER_MIN_DATA_NAME = 'ESTIMATED_DIAMETER_MIN';
-    protected const int ESTIMATED_DIAMETER_MIN_DATA_INDEX = 1;
+    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/LinksTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/LinksTransfer.php
@@ -20,16 +20,15 @@ final class LinksTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::SELF => self::SELF_DATA_NAME,
+        self::SELF_INDEX => self::SELF,
     ];
 
     // self
     public const string SELF = 'self';
-    protected const string SELF_DATA_NAME = 'SELF';
-    protected const int SELF_DATA_INDEX = 0;
+    protected const int SELF_INDEX = 0;
 
     public ?string $self {
-        get => $this->getData(self::SELF_DATA_INDEX);
-        set => $this->setData(self::SELF_DATA_INDEX, $value);
+        get => $this->getData(self::SELF_INDEX);
+        set => $this->setData(self::SELF_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MetersTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MetersTransfer.php
@@ -20,27 +20,25 @@ final class MetersTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ESTIMATED_DIAMETER_MAX => self::ESTIMATED_DIAMETER_MAX_DATA_NAME,
-        self::ESTIMATED_DIAMETER_MIN => self::ESTIMATED_DIAMETER_MIN_DATA_NAME,
+        self::ESTIMATED_DIAMETER_MAX_INDEX => self::ESTIMATED_DIAMETER_MAX,
+        self::ESTIMATED_DIAMETER_MIN_INDEX => self::ESTIMATED_DIAMETER_MIN,
     ];
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const string ESTIMATED_DIAMETER_MAX_DATA_NAME = 'ESTIMATED_DIAMETER_MAX';
-    protected const int ESTIMATED_DIAMETER_MAX_DATA_INDEX = 0;
+    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_INDEX, $value);
     }
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const string ESTIMATED_DIAMETER_MIN_DATA_NAME = 'ESTIMATED_DIAMETER_MIN';
-    protected const int ESTIMATED_DIAMETER_MIN_DATA_INDEX = 1;
+    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MilesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MilesTransfer.php
@@ -20,27 +20,25 @@ final class MilesTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ESTIMATED_DIAMETER_MAX => self::ESTIMATED_DIAMETER_MAX_DATA_NAME,
-        self::ESTIMATED_DIAMETER_MIN => self::ESTIMATED_DIAMETER_MIN_DATA_NAME,
+        self::ESTIMATED_DIAMETER_MAX_INDEX => self::ESTIMATED_DIAMETER_MAX,
+        self::ESTIMATED_DIAMETER_MIN_INDEX => self::ESTIMATED_DIAMETER_MIN,
     ];
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const string ESTIMATED_DIAMETER_MAX_DATA_NAME = 'ESTIMATED_DIAMETER_MAX';
-    protected const int ESTIMATED_DIAMETER_MAX_DATA_INDEX = 0;
+    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MAX_INDEX, $value);
     }
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const string ESTIMATED_DIAMETER_MIN_DATA_NAME = 'ESTIMATED_DIAMETER_MIN';
-    protected const int ESTIMATED_DIAMETER_MIN_DATA_INDEX = 1;
+    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
-        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX);
-        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_DATA_INDEX, $value);
+        get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);
+        set => $this->setData(self::ESTIMATED_DIAMETER_MIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MissDistanceTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MissDistanceTransfer.php
@@ -20,49 +20,45 @@ final class MissDistanceTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::ASTRONOMICAL => self::ASTRONOMICAL_DATA_NAME,
-        self::KILOMETERS => self::KILOMETERS_DATA_NAME,
-        self::LUNAR => self::LUNAR_DATA_NAME,
-        self::MILES => self::MILES_DATA_NAME,
+        self::ASTRONOMICAL_INDEX => self::ASTRONOMICAL,
+        self::KILOMETERS_INDEX => self::KILOMETERS,
+        self::LUNAR_INDEX => self::LUNAR,
+        self::MILES_INDEX => self::MILES,
     ];
 
     // astronomical
     public const string ASTRONOMICAL = 'astronomical';
-    protected const string ASTRONOMICAL_DATA_NAME = 'ASTRONOMICAL';
-    protected const int ASTRONOMICAL_DATA_INDEX = 0;
+    protected const int ASTRONOMICAL_INDEX = 0;
 
     public ?string $astronomical {
-        get => $this->getData(self::ASTRONOMICAL_DATA_INDEX);
-        set => $this->setData(self::ASTRONOMICAL_DATA_INDEX, $value);
+        get => $this->getData(self::ASTRONOMICAL_INDEX);
+        set => $this->setData(self::ASTRONOMICAL_INDEX, $value);
     }
 
     // kilometers
     public const string KILOMETERS = 'kilometers';
-    protected const string KILOMETERS_DATA_NAME = 'KILOMETERS';
-    protected const int KILOMETERS_DATA_INDEX = 1;
+    protected const int KILOMETERS_INDEX = 1;
 
     public ?string $kilometers {
-        get => $this->getData(self::KILOMETERS_DATA_INDEX);
-        set => $this->setData(self::KILOMETERS_DATA_INDEX, $value);
+        get => $this->getData(self::KILOMETERS_INDEX);
+        set => $this->setData(self::KILOMETERS_INDEX, $value);
     }
 
     // lunar
     public const string LUNAR = 'lunar';
-    protected const string LUNAR_DATA_NAME = 'LUNAR';
-    protected const int LUNAR_DATA_INDEX = 2;
+    protected const int LUNAR_INDEX = 2;
 
     public ?string $lunar {
-        get => $this->getData(self::LUNAR_DATA_INDEX);
-        set => $this->setData(self::LUNAR_DATA_INDEX, $value);
+        get => $this->getData(self::LUNAR_INDEX);
+        set => $this->setData(self::LUNAR_INDEX, $value);
     }
 
     // miles
     public const string MILES = 'miles';
-    protected const string MILES_DATA_NAME = 'MILES';
-    protected const int MILES_DATA_INDEX = 3;
+    protected const int MILES_INDEX = 3;
 
     public ?string $miles {
-        get => $this->getData(self::MILES_DATA_INDEX);
-        set => $this->setData(self::MILES_DATA_INDEX, $value);
+        get => $this->getData(self::MILES_INDEX);
+        set => $this->setData(self::MILES_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitClassTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitClassTransfer.php
@@ -20,38 +20,35 @@ final class OrbitClassTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::ORBIT_CLASS_DESCRIPTION => self::ORBIT_CLASS_DESCRIPTION_DATA_NAME,
-        self::ORBIT_CLASS_RANGE => self::ORBIT_CLASS_RANGE_DATA_NAME,
-        self::ORBIT_CLASS_TYPE => self::ORBIT_CLASS_TYPE_DATA_NAME,
+        self::ORBIT_CLASS_DESCRIPTION_INDEX => self::ORBIT_CLASS_DESCRIPTION,
+        self::ORBIT_CLASS_RANGE_INDEX => self::ORBIT_CLASS_RANGE,
+        self::ORBIT_CLASS_TYPE_INDEX => self::ORBIT_CLASS_TYPE,
     ];
 
     // orbit_class_description
     public const string ORBIT_CLASS_DESCRIPTION = 'orbit_class_description';
-    protected const string ORBIT_CLASS_DESCRIPTION_DATA_NAME = 'ORBIT_CLASS_DESCRIPTION';
-    protected const int ORBIT_CLASS_DESCRIPTION_DATA_INDEX = 0;
+    protected const int ORBIT_CLASS_DESCRIPTION_INDEX = 0;
 
     public ?string $orbit_class_description {
-        get => $this->getData(self::ORBIT_CLASS_DESCRIPTION_DATA_INDEX);
-        set => $this->setData(self::ORBIT_CLASS_DESCRIPTION_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_CLASS_DESCRIPTION_INDEX);
+        set => $this->setData(self::ORBIT_CLASS_DESCRIPTION_INDEX, $value);
     }
 
     // orbit_class_range
     public const string ORBIT_CLASS_RANGE = 'orbit_class_range';
-    protected const string ORBIT_CLASS_RANGE_DATA_NAME = 'ORBIT_CLASS_RANGE';
-    protected const int ORBIT_CLASS_RANGE_DATA_INDEX = 1;
+    protected const int ORBIT_CLASS_RANGE_INDEX = 1;
 
     public ?string $orbit_class_range {
-        get => $this->getData(self::ORBIT_CLASS_RANGE_DATA_INDEX);
-        set => $this->setData(self::ORBIT_CLASS_RANGE_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_CLASS_RANGE_INDEX);
+        set => $this->setData(self::ORBIT_CLASS_RANGE_INDEX, $value);
     }
 
     // orbit_class_type
     public const string ORBIT_CLASS_TYPE = 'orbit_class_type';
-    protected const string ORBIT_CLASS_TYPE_DATA_NAME = 'ORBIT_CLASS_TYPE';
-    protected const int ORBIT_CLASS_TYPE_DATA_INDEX = 2;
+    protected const int ORBIT_CLASS_TYPE_INDEX = 2;
 
     public ?string $orbit_class_type {
-        get => $this->getData(self::ORBIT_CLASS_TYPE_DATA_INDEX);
-        set => $this->setData(self::ORBIT_CLASS_TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_CLASS_TYPE_INDEX);
+        set => $this->setData(self::ORBIT_CLASS_TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitalDataTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitalDataTransfer.php
@@ -21,259 +21,236 @@ final class OrbitalDataTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 23;
 
     protected const array META_DATA = [
-        self::APHELION_DISTANCE => self::APHELION_DISTANCE_DATA_NAME,
-        self::ASCENDING_NODE_LONGITUDE => self::ASCENDING_NODE_LONGITUDE_DATA_NAME,
-        self::DATA_ARC_IN_DAYS => self::DATA_ARC_IN_DAYS_DATA_NAME,
-        self::ECCENTRICITY => self::ECCENTRICITY_DATA_NAME,
-        self::EPOCH_OSCULATION => self::EPOCH_OSCULATION_DATA_NAME,
-        self::EQUINOX => self::EQUINOX_DATA_NAME,
-        self::FIRST_OBSERVATION_DATE => self::FIRST_OBSERVATION_DATE_DATA_NAME,
-        self::INCLINATION => self::INCLINATION_DATA_NAME,
-        self::JUPITER_TISSERAND_INVARIANT => self::JUPITER_TISSERAND_INVARIANT_DATA_NAME,
-        self::LAST_OBSERVATION_DATE => self::LAST_OBSERVATION_DATE_DATA_NAME,
-        self::MEAN_ANOMALY => self::MEAN_ANOMALY_DATA_NAME,
-        self::MEAN_MOTION => self::MEAN_MOTION_DATA_NAME,
-        self::MINIMUM_ORBIT_INTERSECTION => self::MINIMUM_ORBIT_INTERSECTION_DATA_NAME,
-        self::OBSERVATIONS_USED => self::OBSERVATIONS_USED_DATA_NAME,
-        self::ORBIT_CLASS => self::ORBIT_CLASS_DATA_NAME,
-        self::ORBIT_DETERMINATION_DATE => self::ORBIT_DETERMINATION_DATE_DATA_NAME,
-        self::ORBIT_ID => self::ORBIT_ID_DATA_NAME,
-        self::ORBIT_UNCERTAINTY => self::ORBIT_UNCERTAINTY_DATA_NAME,
-        self::ORBITAL_PERIOD => self::ORBITAL_PERIOD_DATA_NAME,
-        self::PERIHELION_ARGUMENT => self::PERIHELION_ARGUMENT_DATA_NAME,
-        self::PERIHELION_DISTANCE => self::PERIHELION_DISTANCE_DATA_NAME,
-        self::PERIHELION_TIME => self::PERIHELION_TIME_DATA_NAME,
-        self::SEMI_MAJOR_AXIS => self::SEMI_MAJOR_AXIS_DATA_NAME,
+        self::APHELION_DISTANCE_INDEX => self::APHELION_DISTANCE,
+        self::ASCENDING_NODE_LONGITUDE_INDEX => self::ASCENDING_NODE_LONGITUDE,
+        self::DATA_ARC_IN_DAYS_INDEX => self::DATA_ARC_IN_DAYS,
+        self::ECCENTRICITY_INDEX => self::ECCENTRICITY,
+        self::EPOCH_OSCULATION_INDEX => self::EPOCH_OSCULATION,
+        self::EQUINOX_INDEX => self::EQUINOX,
+        self::FIRST_OBSERVATION_DATE_INDEX => self::FIRST_OBSERVATION_DATE,
+        self::INCLINATION_INDEX => self::INCLINATION,
+        self::JUPITER_TISSERAND_INVARIANT_INDEX => self::JUPITER_TISSERAND_INVARIANT,
+        self::LAST_OBSERVATION_DATE_INDEX => self::LAST_OBSERVATION_DATE,
+        self::MEAN_ANOMALY_INDEX => self::MEAN_ANOMALY,
+        self::MEAN_MOTION_INDEX => self::MEAN_MOTION,
+        self::MINIMUM_ORBIT_INTERSECTION_INDEX => self::MINIMUM_ORBIT_INTERSECTION,
+        self::OBSERVATIONS_USED_INDEX => self::OBSERVATIONS_USED,
+        self::ORBIT_CLASS_INDEX => self::ORBIT_CLASS,
+        self::ORBIT_DETERMINATION_DATE_INDEX => self::ORBIT_DETERMINATION_DATE,
+        self::ORBIT_ID_INDEX => self::ORBIT_ID,
+        self::ORBIT_UNCERTAINTY_INDEX => self::ORBIT_UNCERTAINTY,
+        self::ORBITAL_PERIOD_INDEX => self::ORBITAL_PERIOD,
+        self::PERIHELION_ARGUMENT_INDEX => self::PERIHELION_ARGUMENT,
+        self::PERIHELION_DISTANCE_INDEX => self::PERIHELION_DISTANCE,
+        self::PERIHELION_TIME_INDEX => self::PERIHELION_TIME,
+        self::SEMI_MAJOR_AXIS_INDEX => self::SEMI_MAJOR_AXIS,
     ];
 
     // aphelion_distance
     public const string APHELION_DISTANCE = 'aphelion_distance';
-    protected const string APHELION_DISTANCE_DATA_NAME = 'APHELION_DISTANCE';
-    protected const int APHELION_DISTANCE_DATA_INDEX = 0;
+    protected const int APHELION_DISTANCE_INDEX = 0;
 
     public ?string $aphelion_distance {
-        get => $this->getData(self::APHELION_DISTANCE_DATA_INDEX);
-        set => $this->setData(self::APHELION_DISTANCE_DATA_INDEX, $value);
+        get => $this->getData(self::APHELION_DISTANCE_INDEX);
+        set => $this->setData(self::APHELION_DISTANCE_INDEX, $value);
     }
 
     // ascending_node_longitude
     public const string ASCENDING_NODE_LONGITUDE = 'ascending_node_longitude';
-    protected const string ASCENDING_NODE_LONGITUDE_DATA_NAME = 'ASCENDING_NODE_LONGITUDE';
-    protected const int ASCENDING_NODE_LONGITUDE_DATA_INDEX = 1;
+    protected const int ASCENDING_NODE_LONGITUDE_INDEX = 1;
 
     public ?string $ascending_node_longitude {
-        get => $this->getData(self::ASCENDING_NODE_LONGITUDE_DATA_INDEX);
-        set => $this->setData(self::ASCENDING_NODE_LONGITUDE_DATA_INDEX, $value);
+        get => $this->getData(self::ASCENDING_NODE_LONGITUDE_INDEX);
+        set => $this->setData(self::ASCENDING_NODE_LONGITUDE_INDEX, $value);
     }
 
     // data_arc_in_days
     public const string DATA_ARC_IN_DAYS = 'data_arc_in_days';
-    protected const string DATA_ARC_IN_DAYS_DATA_NAME = 'DATA_ARC_IN_DAYS';
-    protected const int DATA_ARC_IN_DAYS_DATA_INDEX = 2;
+    protected const int DATA_ARC_IN_DAYS_INDEX = 2;
 
     public ?int $data_arc_in_days {
-        get => $this->getData(self::DATA_ARC_IN_DAYS_DATA_INDEX);
-        set => $this->setData(self::DATA_ARC_IN_DAYS_DATA_INDEX, $value);
+        get => $this->getData(self::DATA_ARC_IN_DAYS_INDEX);
+        set => $this->setData(self::DATA_ARC_IN_DAYS_INDEX, $value);
     }
 
     // eccentricity
     public const string ECCENTRICITY = 'eccentricity';
-    protected const string ECCENTRICITY_DATA_NAME = 'ECCENTRICITY';
-    protected const int ECCENTRICITY_DATA_INDEX = 3;
+    protected const int ECCENTRICITY_INDEX = 3;
 
     public ?string $eccentricity {
-        get => $this->getData(self::ECCENTRICITY_DATA_INDEX);
-        set => $this->setData(self::ECCENTRICITY_DATA_INDEX, $value);
+        get => $this->getData(self::ECCENTRICITY_INDEX);
+        set => $this->setData(self::ECCENTRICITY_INDEX, $value);
     }
 
     // epoch_osculation
     public const string EPOCH_OSCULATION = 'epoch_osculation';
-    protected const string EPOCH_OSCULATION_DATA_NAME = 'EPOCH_OSCULATION';
-    protected const int EPOCH_OSCULATION_DATA_INDEX = 4;
+    protected const int EPOCH_OSCULATION_INDEX = 4;
 
     public ?string $epoch_osculation {
-        get => $this->getData(self::EPOCH_OSCULATION_DATA_INDEX);
-        set => $this->setData(self::EPOCH_OSCULATION_DATA_INDEX, $value);
+        get => $this->getData(self::EPOCH_OSCULATION_INDEX);
+        set => $this->setData(self::EPOCH_OSCULATION_INDEX, $value);
     }
 
     // equinox
     public const string EQUINOX = 'equinox';
-    protected const string EQUINOX_DATA_NAME = 'EQUINOX';
-    protected const int EQUINOX_DATA_INDEX = 5;
+    protected const int EQUINOX_INDEX = 5;
 
     public ?string $equinox {
-        get => $this->getData(self::EQUINOX_DATA_INDEX);
-        set => $this->setData(self::EQUINOX_DATA_INDEX, $value);
+        get => $this->getData(self::EQUINOX_INDEX);
+        set => $this->setData(self::EQUINOX_INDEX, $value);
     }
 
     // first_observation_date
     public const string FIRST_OBSERVATION_DATE = 'first_observation_date';
-    protected const string FIRST_OBSERVATION_DATE_DATA_NAME = 'FIRST_OBSERVATION_DATE';
-    protected const int FIRST_OBSERVATION_DATE_DATA_INDEX = 6;
+    protected const int FIRST_OBSERVATION_DATE_INDEX = 6;
 
     public ?string $first_observation_date {
-        get => $this->getData(self::FIRST_OBSERVATION_DATE_DATA_INDEX);
-        set => $this->setData(self::FIRST_OBSERVATION_DATE_DATA_INDEX, $value);
+        get => $this->getData(self::FIRST_OBSERVATION_DATE_INDEX);
+        set => $this->setData(self::FIRST_OBSERVATION_DATE_INDEX, $value);
     }
 
     // inclination
     public const string INCLINATION = 'inclination';
-    protected const string INCLINATION_DATA_NAME = 'INCLINATION';
-    protected const int INCLINATION_DATA_INDEX = 7;
+    protected const int INCLINATION_INDEX = 7;
 
     public ?string $inclination {
-        get => $this->getData(self::INCLINATION_DATA_INDEX);
-        set => $this->setData(self::INCLINATION_DATA_INDEX, $value);
+        get => $this->getData(self::INCLINATION_INDEX);
+        set => $this->setData(self::INCLINATION_INDEX, $value);
     }
 
     // jupiter_tisserand_invariant
     public const string JUPITER_TISSERAND_INVARIANT = 'jupiter_tisserand_invariant';
-    protected const string JUPITER_TISSERAND_INVARIANT_DATA_NAME = 'JUPITER_TISSERAND_INVARIANT';
-    protected const int JUPITER_TISSERAND_INVARIANT_DATA_INDEX = 8;
+    protected const int JUPITER_TISSERAND_INVARIANT_INDEX = 8;
 
     public ?string $jupiter_tisserand_invariant {
-        get => $this->getData(self::JUPITER_TISSERAND_INVARIANT_DATA_INDEX);
-        set => $this->setData(self::JUPITER_TISSERAND_INVARIANT_DATA_INDEX, $value);
+        get => $this->getData(self::JUPITER_TISSERAND_INVARIANT_INDEX);
+        set => $this->setData(self::JUPITER_TISSERAND_INVARIANT_INDEX, $value);
     }
 
     // last_observation_date
     public const string LAST_OBSERVATION_DATE = 'last_observation_date';
-    protected const string LAST_OBSERVATION_DATE_DATA_NAME = 'LAST_OBSERVATION_DATE';
-    protected const int LAST_OBSERVATION_DATE_DATA_INDEX = 9;
+    protected const int LAST_OBSERVATION_DATE_INDEX = 9;
 
     public ?string $last_observation_date {
-        get => $this->getData(self::LAST_OBSERVATION_DATE_DATA_INDEX);
-        set => $this->setData(self::LAST_OBSERVATION_DATE_DATA_INDEX, $value);
+        get => $this->getData(self::LAST_OBSERVATION_DATE_INDEX);
+        set => $this->setData(self::LAST_OBSERVATION_DATE_INDEX, $value);
     }
 
     // mean_anomaly
     public const string MEAN_ANOMALY = 'mean_anomaly';
-    protected const string MEAN_ANOMALY_DATA_NAME = 'MEAN_ANOMALY';
-    protected const int MEAN_ANOMALY_DATA_INDEX = 10;
+    protected const int MEAN_ANOMALY_INDEX = 10;
 
     public ?string $mean_anomaly {
-        get => $this->getData(self::MEAN_ANOMALY_DATA_INDEX);
-        set => $this->setData(self::MEAN_ANOMALY_DATA_INDEX, $value);
+        get => $this->getData(self::MEAN_ANOMALY_INDEX);
+        set => $this->setData(self::MEAN_ANOMALY_INDEX, $value);
     }
 
     // mean_motion
     public const string MEAN_MOTION = 'mean_motion';
-    protected const string MEAN_MOTION_DATA_NAME = 'MEAN_MOTION';
-    protected const int MEAN_MOTION_DATA_INDEX = 11;
+    protected const int MEAN_MOTION_INDEX = 11;
 
     public ?string $mean_motion {
-        get => $this->getData(self::MEAN_MOTION_DATA_INDEX);
-        set => $this->setData(self::MEAN_MOTION_DATA_INDEX, $value);
+        get => $this->getData(self::MEAN_MOTION_INDEX);
+        set => $this->setData(self::MEAN_MOTION_INDEX, $value);
     }
 
     // minimum_orbit_intersection
     public const string MINIMUM_ORBIT_INTERSECTION = 'minimum_orbit_intersection';
-    protected const string MINIMUM_ORBIT_INTERSECTION_DATA_NAME = 'MINIMUM_ORBIT_INTERSECTION';
-    protected const int MINIMUM_ORBIT_INTERSECTION_DATA_INDEX = 12;
+    protected const int MINIMUM_ORBIT_INTERSECTION_INDEX = 12;
 
     public ?string $minimum_orbit_intersection {
-        get => $this->getData(self::MINIMUM_ORBIT_INTERSECTION_DATA_INDEX);
-        set => $this->setData(self::MINIMUM_ORBIT_INTERSECTION_DATA_INDEX, $value);
+        get => $this->getData(self::MINIMUM_ORBIT_INTERSECTION_INDEX);
+        set => $this->setData(self::MINIMUM_ORBIT_INTERSECTION_INDEX, $value);
     }
 
     // observations_used
     public const string OBSERVATIONS_USED = 'observations_used';
-    protected const string OBSERVATIONS_USED_DATA_NAME = 'OBSERVATIONS_USED';
-    protected const int OBSERVATIONS_USED_DATA_INDEX = 13;
+    protected const int OBSERVATIONS_USED_INDEX = 13;
 
     public ?int $observations_used {
-        get => $this->getData(self::OBSERVATIONS_USED_DATA_INDEX);
-        set => $this->setData(self::OBSERVATIONS_USED_DATA_INDEX, $value);
+        get => $this->getData(self::OBSERVATIONS_USED_INDEX);
+        set => $this->setData(self::OBSERVATIONS_USED_INDEX, $value);
     }
 
     // orbit_class
     #[PropertyTypeAttribute(OrbitClassTransfer::class)]
     public const string ORBIT_CLASS = 'orbit_class';
-    protected const string ORBIT_CLASS_DATA_NAME = 'ORBIT_CLASS';
-    protected const int ORBIT_CLASS_DATA_INDEX = 14;
+    protected const int ORBIT_CLASS_INDEX = 14;
 
     public ?OrbitClassTransfer $orbit_class {
-        get => $this->getData(self::ORBIT_CLASS_DATA_INDEX);
-        set => $this->setData(self::ORBIT_CLASS_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_CLASS_INDEX);
+        set => $this->setData(self::ORBIT_CLASS_INDEX, $value);
     }
 
     // orbit_determination_date
     public const string ORBIT_DETERMINATION_DATE = 'orbit_determination_date';
-    protected const string ORBIT_DETERMINATION_DATE_DATA_NAME = 'ORBIT_DETERMINATION_DATE';
-    protected const int ORBIT_DETERMINATION_DATE_DATA_INDEX = 15;
+    protected const int ORBIT_DETERMINATION_DATE_INDEX = 15;
 
     public ?string $orbit_determination_date {
-        get => $this->getData(self::ORBIT_DETERMINATION_DATE_DATA_INDEX);
-        set => $this->setData(self::ORBIT_DETERMINATION_DATE_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_DETERMINATION_DATE_INDEX);
+        set => $this->setData(self::ORBIT_DETERMINATION_DATE_INDEX, $value);
     }
 
     // orbit_id
     public const string ORBIT_ID = 'orbit_id';
-    protected const string ORBIT_ID_DATA_NAME = 'ORBIT_ID';
-    protected const int ORBIT_ID_DATA_INDEX = 16;
+    protected const int ORBIT_ID_INDEX = 16;
 
     public ?string $orbit_id {
-        get => $this->getData(self::ORBIT_ID_DATA_INDEX);
-        set => $this->setData(self::ORBIT_ID_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_ID_INDEX);
+        set => $this->setData(self::ORBIT_ID_INDEX, $value);
     }
 
     // orbit_uncertainty
     public const string ORBIT_UNCERTAINTY = 'orbit_uncertainty';
-    protected const string ORBIT_UNCERTAINTY_DATA_NAME = 'ORBIT_UNCERTAINTY';
-    protected const int ORBIT_UNCERTAINTY_DATA_INDEX = 17;
+    protected const int ORBIT_UNCERTAINTY_INDEX = 17;
 
     public ?string $orbit_uncertainty {
-        get => $this->getData(self::ORBIT_UNCERTAINTY_DATA_INDEX);
-        set => $this->setData(self::ORBIT_UNCERTAINTY_DATA_INDEX, $value);
+        get => $this->getData(self::ORBIT_UNCERTAINTY_INDEX);
+        set => $this->setData(self::ORBIT_UNCERTAINTY_INDEX, $value);
     }
 
     // orbital_period
     public const string ORBITAL_PERIOD = 'orbital_period';
-    protected const string ORBITAL_PERIOD_DATA_NAME = 'ORBITAL_PERIOD';
-    protected const int ORBITAL_PERIOD_DATA_INDEX = 18;
+    protected const int ORBITAL_PERIOD_INDEX = 18;
 
     public ?string $orbital_period {
-        get => $this->getData(self::ORBITAL_PERIOD_DATA_INDEX);
-        set => $this->setData(self::ORBITAL_PERIOD_DATA_INDEX, $value);
+        get => $this->getData(self::ORBITAL_PERIOD_INDEX);
+        set => $this->setData(self::ORBITAL_PERIOD_INDEX, $value);
     }
 
     // perihelion_argument
     public const string PERIHELION_ARGUMENT = 'perihelion_argument';
-    protected const string PERIHELION_ARGUMENT_DATA_NAME = 'PERIHELION_ARGUMENT';
-    protected const int PERIHELION_ARGUMENT_DATA_INDEX = 19;
+    protected const int PERIHELION_ARGUMENT_INDEX = 19;
 
     public ?string $perihelion_argument {
-        get => $this->getData(self::PERIHELION_ARGUMENT_DATA_INDEX);
-        set => $this->setData(self::PERIHELION_ARGUMENT_DATA_INDEX, $value);
+        get => $this->getData(self::PERIHELION_ARGUMENT_INDEX);
+        set => $this->setData(self::PERIHELION_ARGUMENT_INDEX, $value);
     }
 
     // perihelion_distance
     public const string PERIHELION_DISTANCE = 'perihelion_distance';
-    protected const string PERIHELION_DISTANCE_DATA_NAME = 'PERIHELION_DISTANCE';
-    protected const int PERIHELION_DISTANCE_DATA_INDEX = 20;
+    protected const int PERIHELION_DISTANCE_INDEX = 20;
 
     public ?string $perihelion_distance {
-        get => $this->getData(self::PERIHELION_DISTANCE_DATA_INDEX);
-        set => $this->setData(self::PERIHELION_DISTANCE_DATA_INDEX, $value);
+        get => $this->getData(self::PERIHELION_DISTANCE_INDEX);
+        set => $this->setData(self::PERIHELION_DISTANCE_INDEX, $value);
     }
 
     // perihelion_time
     public const string PERIHELION_TIME = 'perihelion_time';
-    protected const string PERIHELION_TIME_DATA_NAME = 'PERIHELION_TIME';
-    protected const int PERIHELION_TIME_DATA_INDEX = 21;
+    protected const int PERIHELION_TIME_INDEX = 21;
 
     public ?string $perihelion_time {
-        get => $this->getData(self::PERIHELION_TIME_DATA_INDEX);
-        set => $this->setData(self::PERIHELION_TIME_DATA_INDEX, $value);
+        get => $this->getData(self::PERIHELION_TIME_INDEX);
+        set => $this->setData(self::PERIHELION_TIME_INDEX, $value);
     }
 
     // semi_major_axis
     public const string SEMI_MAJOR_AXIS = 'semi_major_axis';
-    protected const string SEMI_MAJOR_AXIS_DATA_NAME = 'SEMI_MAJOR_AXIS';
-    protected const int SEMI_MAJOR_AXIS_DATA_INDEX = 22;
+    protected const int SEMI_MAJOR_AXIS_INDEX = 22;
 
     public ?string $semi_major_axis {
-        get => $this->getData(self::SEMI_MAJOR_AXIS_DATA_INDEX);
-        set => $this->setData(self::SEMI_MAJOR_AXIS_DATA_INDEX, $value);
+        get => $this->getData(self::SEMI_MAJOR_AXIS_INDEX);
+        set => $this->setData(self::SEMI_MAJOR_AXIS_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/RelativeVelocityTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/RelativeVelocityTransfer.php
@@ -20,38 +20,35 @@ final class RelativeVelocityTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::KILOMETERS_PER_HOUR => self::KILOMETERS_PER_HOUR_DATA_NAME,
-        self::KILOMETERS_PER_SECOND => self::KILOMETERS_PER_SECOND_DATA_NAME,
-        self::MILES_PER_HOUR => self::MILES_PER_HOUR_DATA_NAME,
+        self::KILOMETERS_PER_HOUR_INDEX => self::KILOMETERS_PER_HOUR,
+        self::KILOMETERS_PER_SECOND_INDEX => self::KILOMETERS_PER_SECOND,
+        self::MILES_PER_HOUR_INDEX => self::MILES_PER_HOUR,
     ];
 
     // kilometers_per_hour
     public const string KILOMETERS_PER_HOUR = 'kilometers_per_hour';
-    protected const string KILOMETERS_PER_HOUR_DATA_NAME = 'KILOMETERS_PER_HOUR';
-    protected const int KILOMETERS_PER_HOUR_DATA_INDEX = 0;
+    protected const int KILOMETERS_PER_HOUR_INDEX = 0;
 
     public ?string $kilometers_per_hour {
-        get => $this->getData(self::KILOMETERS_PER_HOUR_DATA_INDEX);
-        set => $this->setData(self::KILOMETERS_PER_HOUR_DATA_INDEX, $value);
+        get => $this->getData(self::KILOMETERS_PER_HOUR_INDEX);
+        set => $this->setData(self::KILOMETERS_PER_HOUR_INDEX, $value);
     }
 
     // kilometers_per_second
     public const string KILOMETERS_PER_SECOND = 'kilometers_per_second';
-    protected const string KILOMETERS_PER_SECOND_DATA_NAME = 'KILOMETERS_PER_SECOND';
-    protected const int KILOMETERS_PER_SECOND_DATA_INDEX = 1;
+    protected const int KILOMETERS_PER_SECOND_INDEX = 1;
 
     public ?string $kilometers_per_second {
-        get => $this->getData(self::KILOMETERS_PER_SECOND_DATA_INDEX);
-        set => $this->setData(self::KILOMETERS_PER_SECOND_DATA_INDEX, $value);
+        get => $this->getData(self::KILOMETERS_PER_SECOND_INDEX);
+        set => $this->setData(self::KILOMETERS_PER_SECOND_INDEX, $value);
     }
 
     // miles_per_hour
     public const string MILES_PER_HOUR = 'miles_per_hour';
-    protected const string MILES_PER_HOUR_DATA_NAME = 'MILES_PER_HOUR';
-    protected const int MILES_PER_HOUR_DATA_INDEX = 2;
+    protected const int MILES_PER_HOUR_INDEX = 2;
 
     public ?string $miles_per_hour {
-        get => $this->getData(self::MILES_PER_HOUR_DATA_INDEX);
-        set => $this->setData(self::MILES_PER_HOUR_DATA_INDEX, $value);
+        get => $this->getData(self::MILES_PER_HOUR_INDEX);
+        set => $this->setData(self::MILES_PER_HOUR_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/CloudsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/CloudsTransfer.php
@@ -20,16 +20,15 @@ final class CloudsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::ALL => self::ALL_DATA_NAME,
+        self::ALL_INDEX => self::ALL,
     ];
 
     // all
     public const string ALL = 'all';
-    protected const string ALL_DATA_NAME = 'ALL';
-    protected const int ALL_DATA_INDEX = 0;
+    protected const int ALL_INDEX = 0;
 
     public ?int $all {
-        get => $this->getData(self::ALL_DATA_INDEX);
-        set => $this->setData(self::ALL_DATA_INDEX, $value);
+        get => $this->getData(self::ALL_INDEX);
+        set => $this->setData(self::ALL_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/CoordTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/CoordTransfer.php
@@ -20,27 +20,25 @@ final class CoordTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::LAT => self::LAT_DATA_NAME,
-        self::LON => self::LON_DATA_NAME,
+        self::LAT_INDEX => self::LAT,
+        self::LON_INDEX => self::LON,
     ];
 
     // lat
     public const string LAT = 'lat';
-    protected const string LAT_DATA_NAME = 'LAT';
-    protected const int LAT_DATA_INDEX = 0;
+    protected const int LAT_INDEX = 0;
 
     public ?float $lat {
-        get => $this->getData(self::LAT_DATA_INDEX);
-        set => $this->setData(self::LAT_DATA_INDEX, $value);
+        get => $this->getData(self::LAT_INDEX);
+        set => $this->setData(self::LAT_INDEX, $value);
     }
 
     // lon
     public const string LON = 'lon';
-    protected const string LON_DATA_NAME = 'LON';
-    protected const int LON_DATA_INDEX = 1;
+    protected const int LON_INDEX = 1;
 
     public ?float $lon {
-        get => $this->getData(self::LON_DATA_INDEX);
-        set => $this->setData(self::LON_DATA_INDEX, $value);
+        get => $this->getData(self::LON_INDEX);
+        set => $this->setData(self::LON_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/ForecastTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/ForecastTransfer.php
@@ -24,168 +24,154 @@ final class ForecastTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 14;
 
     protected const array META_DATA = [
-        self::BASE => self::BASE_DATA_NAME,
-        self::CLOUDS => self::CLOUDS_DATA_NAME,
-        self::COD => self::COD_DATA_NAME,
-        self::COORD => self::COORD_DATA_NAME,
-        self::DT => self::DT_DATA_NAME,
-        self::ID => self::ID_DATA_NAME,
-        self::MAIN => self::MAIN_DATA_NAME,
-        self::NAME => self::NAME_DATA_NAME,
-        self::RAIN => self::RAIN_DATA_NAME,
-        self::SYS => self::SYS_DATA_NAME,
-        self::TIMEZONE => self::TIMEZONE_DATA_NAME,
-        self::VISIBILITY => self::VISIBILITY_DATA_NAME,
-        self::WEATHER => self::WEATHER_DATA_NAME,
-        self::WIND => self::WIND_DATA_NAME,
+        self::BASE_INDEX => self::BASE,
+        self::CLOUDS_INDEX => self::CLOUDS,
+        self::COD_INDEX => self::COD,
+        self::COORD_INDEX => self::COORD,
+        self::DT_INDEX => self::DT,
+        self::ID_INDEX => self::ID,
+        self::MAIN_INDEX => self::MAIN,
+        self::NAME_INDEX => self::NAME,
+        self::RAIN_INDEX => self::RAIN,
+        self::SYS_INDEX => self::SYS,
+        self::TIMEZONE_INDEX => self::TIMEZONE,
+        self::VISIBILITY_INDEX => self::VISIBILITY,
+        self::WEATHER_INDEX => self::WEATHER,
+        self::WIND_INDEX => self::WIND,
     ];
 
     // base
     public const string BASE = 'base';
-    protected const string BASE_DATA_NAME = 'BASE';
-    protected const int BASE_DATA_INDEX = 0;
+    protected const int BASE_INDEX = 0;
 
     public ?string $base {
-        get => $this->getData(self::BASE_DATA_INDEX);
-        set => $this->setData(self::BASE_DATA_INDEX, $value);
+        get => $this->getData(self::BASE_INDEX);
+        set => $this->setData(self::BASE_INDEX, $value);
     }
 
     // clouds
     #[PropertyTypeAttribute(CloudsTransfer::class)]
     public const string CLOUDS = 'clouds';
-    protected const string CLOUDS_DATA_NAME = 'CLOUDS';
-    protected const int CLOUDS_DATA_INDEX = 1;
+    protected const int CLOUDS_INDEX = 1;
 
     public ?CloudsTransfer $clouds {
-        get => $this->getData(self::CLOUDS_DATA_INDEX);
-        set => $this->setData(self::CLOUDS_DATA_INDEX, $value);
+        get => $this->getData(self::CLOUDS_INDEX);
+        set => $this->setData(self::CLOUDS_INDEX, $value);
     }
 
     // cod
     public const string COD = 'cod';
-    protected const string COD_DATA_NAME = 'COD';
-    protected const int COD_DATA_INDEX = 2;
+    protected const int COD_INDEX = 2;
 
     public ?int $cod {
-        get => $this->getData(self::COD_DATA_INDEX);
-        set => $this->setData(self::COD_DATA_INDEX, $value);
+        get => $this->getData(self::COD_INDEX);
+        set => $this->setData(self::COD_INDEX, $value);
     }
 
     // coord
     #[PropertyTypeAttribute(CoordTransfer::class)]
     public const string COORD = 'coord';
-    protected const string COORD_DATA_NAME = 'COORD';
-    protected const int COORD_DATA_INDEX = 3;
+    protected const int COORD_INDEX = 3;
 
     public ?CoordTransfer $coord {
-        get => $this->getData(self::COORD_DATA_INDEX);
-        set => $this->setData(self::COORD_DATA_INDEX, $value);
+        get => $this->getData(self::COORD_INDEX);
+        set => $this->setData(self::COORD_INDEX, $value);
     }
 
     // dt
     public const string DT = 'dt';
-    protected const string DT_DATA_NAME = 'DT';
-    protected const int DT_DATA_INDEX = 4;
+    protected const int DT_INDEX = 4;
 
     public ?int $dt {
-        get => $this->getData(self::DT_DATA_INDEX);
-        set => $this->setData(self::DT_DATA_INDEX, $value);
+        get => $this->getData(self::DT_INDEX);
+        set => $this->setData(self::DT_INDEX, $value);
     }
 
     // id
     public const string ID = 'id';
-    protected const string ID_DATA_NAME = 'ID';
-    protected const int ID_DATA_INDEX = 5;
+    protected const int ID_INDEX = 5;
 
     public ?int $id {
-        get => $this->getData(self::ID_DATA_INDEX);
-        set => $this->setData(self::ID_DATA_INDEX, $value);
+        get => $this->getData(self::ID_INDEX);
+        set => $this->setData(self::ID_INDEX, $value);
     }
 
     // main
     #[PropertyTypeAttribute(MainTransfer::class)]
     public const string MAIN = 'main';
-    protected const string MAIN_DATA_NAME = 'MAIN';
-    protected const int MAIN_DATA_INDEX = 6;
+    protected const int MAIN_INDEX = 6;
 
     public ?MainTransfer $main {
-        get => $this->getData(self::MAIN_DATA_INDEX);
-        set => $this->setData(self::MAIN_DATA_INDEX, $value);
+        get => $this->getData(self::MAIN_INDEX);
+        set => $this->setData(self::MAIN_INDEX, $value);
     }
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 7;
+    protected const int NAME_INDEX = 7;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 
     // rain
     #[ArrayPropertyTypeAttribute]
     public const string RAIN = 'rain';
-    protected const string RAIN_DATA_NAME = 'RAIN';
-    protected const int RAIN_DATA_INDEX = 8;
+    protected const int RAIN_INDEX = 8;
 
     /** @var array<int|string,mixed> */
     public array $rain {
-        get => $this->getData(self::RAIN_DATA_INDEX);
-        set => $this->setData(self::RAIN_DATA_INDEX, $value);
+        get => $this->getData(self::RAIN_INDEX);
+        set => $this->setData(self::RAIN_INDEX, $value);
     }
 
     // sys
     #[PropertyTypeAttribute(SysTransfer::class)]
     public const string SYS = 'sys';
-    protected const string SYS_DATA_NAME = 'SYS';
-    protected const int SYS_DATA_INDEX = 9;
+    protected const int SYS_INDEX = 9;
 
     public ?SysTransfer $sys {
-        get => $this->getData(self::SYS_DATA_INDEX);
-        set => $this->setData(self::SYS_DATA_INDEX, $value);
+        get => $this->getData(self::SYS_INDEX);
+        set => $this->setData(self::SYS_INDEX, $value);
     }
 
     // timezone
     public const string TIMEZONE = 'timezone';
-    protected const string TIMEZONE_DATA_NAME = 'TIMEZONE';
-    protected const int TIMEZONE_DATA_INDEX = 10;
+    protected const int TIMEZONE_INDEX = 10;
 
     public ?int $timezone {
-        get => $this->getData(self::TIMEZONE_DATA_INDEX);
-        set => $this->setData(self::TIMEZONE_DATA_INDEX, $value);
+        get => $this->getData(self::TIMEZONE_INDEX);
+        set => $this->setData(self::TIMEZONE_INDEX, $value);
     }
 
     // visibility
     public const string VISIBILITY = 'visibility';
-    protected const string VISIBILITY_DATA_NAME = 'VISIBILITY';
-    protected const int VISIBILITY_DATA_INDEX = 11;
+    protected const int VISIBILITY_INDEX = 11;
 
     public ?int $visibility {
-        get => $this->getData(self::VISIBILITY_DATA_INDEX);
-        set => $this->setData(self::VISIBILITY_DATA_INDEX, $value);
+        get => $this->getData(self::VISIBILITY_INDEX);
+        set => $this->setData(self::VISIBILITY_INDEX, $value);
     }
 
     // weather
     #[CollectionPropertyTypeAttribute(WeatherTransfer::class)]
     public const string WEATHER = 'weather';
-    protected const string WEATHER_DATA_NAME = 'WEATHER';
-    protected const int WEATHER_DATA_INDEX = 12;
+    protected const int WEATHER_INDEX = 12;
 
     /** @var \ArrayObject<int,WeatherTransfer> */
     public ArrayObject $weather {
-        get => $this->getData(self::WEATHER_DATA_INDEX);
-        set => $this->setData(self::WEATHER_DATA_INDEX, $value);
+        get => $this->getData(self::WEATHER_INDEX);
+        set => $this->setData(self::WEATHER_INDEX, $value);
     }
 
     // wind
     #[PropertyTypeAttribute(WindTransfer::class)]
     public const string WIND = 'wind';
-    protected const string WIND_DATA_NAME = 'WIND';
-    protected const int WIND_DATA_INDEX = 13;
+    protected const int WIND_INDEX = 13;
 
     public ?WindTransfer $wind {
-        get => $this->getData(self::WIND_DATA_INDEX);
-        set => $this->setData(self::WIND_DATA_INDEX, $value);
+        get => $this->getData(self::WIND_INDEX);
+        set => $this->setData(self::WIND_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/MainTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/MainTransfer.php
@@ -20,93 +20,85 @@ final class MainTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 8;
 
     protected const array META_DATA = [
-        self::FEELS_LIKE => self::FEELS_LIKE_DATA_NAME,
-        self::GRND_LEVEL => self::GRND_LEVEL_DATA_NAME,
-        self::HUMIDITY => self::HUMIDITY_DATA_NAME,
-        self::PRESSURE => self::PRESSURE_DATA_NAME,
-        self::SEA_LEVEL => self::SEA_LEVEL_DATA_NAME,
-        self::TEMP => self::TEMP_DATA_NAME,
-        self::TEMP_MAX => self::TEMP_MAX_DATA_NAME,
-        self::TEMP_MIN => self::TEMP_MIN_DATA_NAME,
+        self::FEELS_LIKE_INDEX => self::FEELS_LIKE,
+        self::GRND_LEVEL_INDEX => self::GRND_LEVEL,
+        self::HUMIDITY_INDEX => self::HUMIDITY,
+        self::PRESSURE_INDEX => self::PRESSURE,
+        self::SEA_LEVEL_INDEX => self::SEA_LEVEL,
+        self::TEMP_INDEX => self::TEMP,
+        self::TEMP_MAX_INDEX => self::TEMP_MAX,
+        self::TEMP_MIN_INDEX => self::TEMP_MIN,
     ];
 
     // feels_like
     public const string FEELS_LIKE = 'feels_like';
-    protected const string FEELS_LIKE_DATA_NAME = 'FEELS_LIKE';
-    protected const int FEELS_LIKE_DATA_INDEX = 0;
+    protected const int FEELS_LIKE_INDEX = 0;
 
     public ?float $feels_like {
-        get => $this->getData(self::FEELS_LIKE_DATA_INDEX);
-        set => $this->setData(self::FEELS_LIKE_DATA_INDEX, $value);
+        get => $this->getData(self::FEELS_LIKE_INDEX);
+        set => $this->setData(self::FEELS_LIKE_INDEX, $value);
     }
 
     // grnd_level
     public const string GRND_LEVEL = 'grnd_level';
-    protected const string GRND_LEVEL_DATA_NAME = 'GRND_LEVEL';
-    protected const int GRND_LEVEL_DATA_INDEX = 1;
+    protected const int GRND_LEVEL_INDEX = 1;
 
     public ?int $grnd_level {
-        get => $this->getData(self::GRND_LEVEL_DATA_INDEX);
-        set => $this->setData(self::GRND_LEVEL_DATA_INDEX, $value);
+        get => $this->getData(self::GRND_LEVEL_INDEX);
+        set => $this->setData(self::GRND_LEVEL_INDEX, $value);
     }
 
     // humidity
     public const string HUMIDITY = 'humidity';
-    protected const string HUMIDITY_DATA_NAME = 'HUMIDITY';
-    protected const int HUMIDITY_DATA_INDEX = 2;
+    protected const int HUMIDITY_INDEX = 2;
 
     public ?int $humidity {
-        get => $this->getData(self::HUMIDITY_DATA_INDEX);
-        set => $this->setData(self::HUMIDITY_DATA_INDEX, $value);
+        get => $this->getData(self::HUMIDITY_INDEX);
+        set => $this->setData(self::HUMIDITY_INDEX, $value);
     }
 
     // pressure
     public const string PRESSURE = 'pressure';
-    protected const string PRESSURE_DATA_NAME = 'PRESSURE';
-    protected const int PRESSURE_DATA_INDEX = 3;
+    protected const int PRESSURE_INDEX = 3;
 
     public ?int $pressure {
-        get => $this->getData(self::PRESSURE_DATA_INDEX);
-        set => $this->setData(self::PRESSURE_DATA_INDEX, $value);
+        get => $this->getData(self::PRESSURE_INDEX);
+        set => $this->setData(self::PRESSURE_INDEX, $value);
     }
 
     // sea_level
     public const string SEA_LEVEL = 'sea_level';
-    protected const string SEA_LEVEL_DATA_NAME = 'SEA_LEVEL';
-    protected const int SEA_LEVEL_DATA_INDEX = 4;
+    protected const int SEA_LEVEL_INDEX = 4;
 
     public ?int $sea_level {
-        get => $this->getData(self::SEA_LEVEL_DATA_INDEX);
-        set => $this->setData(self::SEA_LEVEL_DATA_INDEX, $value);
+        get => $this->getData(self::SEA_LEVEL_INDEX);
+        set => $this->setData(self::SEA_LEVEL_INDEX, $value);
     }
 
     // temp
     public const string TEMP = 'temp';
-    protected const string TEMP_DATA_NAME = 'TEMP';
-    protected const int TEMP_DATA_INDEX = 5;
+    protected const int TEMP_INDEX = 5;
 
     public ?float $temp {
-        get => $this->getData(self::TEMP_DATA_INDEX);
-        set => $this->setData(self::TEMP_DATA_INDEX, $value);
+        get => $this->getData(self::TEMP_INDEX);
+        set => $this->setData(self::TEMP_INDEX, $value);
     }
 
     // temp_max
     public const string TEMP_MAX = 'temp_max';
-    protected const string TEMP_MAX_DATA_NAME = 'TEMP_MAX';
-    protected const int TEMP_MAX_DATA_INDEX = 6;
+    protected const int TEMP_MAX_INDEX = 6;
 
     public ?float $temp_max {
-        get => $this->getData(self::TEMP_MAX_DATA_INDEX);
-        set => $this->setData(self::TEMP_MAX_DATA_INDEX, $value);
+        get => $this->getData(self::TEMP_MAX_INDEX);
+        set => $this->setData(self::TEMP_MAX_INDEX, $value);
     }
 
     // temp_min
     public const string TEMP_MIN = 'temp_min';
-    protected const string TEMP_MIN_DATA_NAME = 'TEMP_MIN';
-    protected const int TEMP_MIN_DATA_INDEX = 7;
+    protected const int TEMP_MIN_INDEX = 7;
 
     public ?float $temp_min {
-        get => $this->getData(self::TEMP_MIN_DATA_INDEX);
-        set => $this->setData(self::TEMP_MIN_DATA_INDEX, $value);
+        get => $this->getData(self::TEMP_MIN_INDEX);
+        set => $this->setData(self::TEMP_MIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/SysTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/SysTransfer.php
@@ -20,60 +20,55 @@ final class SysTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 5;
 
     protected const array META_DATA = [
-        self::COUNTRY => self::COUNTRY_DATA_NAME,
-        self::ID => self::ID_DATA_NAME,
-        self::SUNRISE => self::SUNRISE_DATA_NAME,
-        self::SUNSET => self::SUNSET_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::COUNTRY_INDEX => self::COUNTRY,
+        self::ID_INDEX => self::ID,
+        self::SUNRISE_INDEX => self::SUNRISE,
+        self::SUNSET_INDEX => self::SUNSET,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // country
     public const string COUNTRY = 'country';
-    protected const string COUNTRY_DATA_NAME = 'COUNTRY';
-    protected const int COUNTRY_DATA_INDEX = 0;
+    protected const int COUNTRY_INDEX = 0;
 
     public ?string $country {
-        get => $this->getData(self::COUNTRY_DATA_INDEX);
-        set => $this->setData(self::COUNTRY_DATA_INDEX, $value);
+        get => $this->getData(self::COUNTRY_INDEX);
+        set => $this->setData(self::COUNTRY_INDEX, $value);
     }
 
     // id
     public const string ID = 'id';
-    protected const string ID_DATA_NAME = 'ID';
-    protected const int ID_DATA_INDEX = 1;
+    protected const int ID_INDEX = 1;
 
     public ?int $id {
-        get => $this->getData(self::ID_DATA_INDEX);
-        set => $this->setData(self::ID_DATA_INDEX, $value);
+        get => $this->getData(self::ID_INDEX);
+        set => $this->setData(self::ID_INDEX, $value);
     }
 
     // sunrise
     public const string SUNRISE = 'sunrise';
-    protected const string SUNRISE_DATA_NAME = 'SUNRISE';
-    protected const int SUNRISE_DATA_INDEX = 2;
+    protected const int SUNRISE_INDEX = 2;
 
     public ?int $sunrise {
-        get => $this->getData(self::SUNRISE_DATA_INDEX);
-        set => $this->setData(self::SUNRISE_DATA_INDEX, $value);
+        get => $this->getData(self::SUNRISE_INDEX);
+        set => $this->setData(self::SUNRISE_INDEX, $value);
     }
 
     // sunset
     public const string SUNSET = 'sunset';
-    protected const string SUNSET_DATA_NAME = 'SUNSET';
-    protected const int SUNSET_DATA_INDEX = 3;
+    protected const int SUNSET_INDEX = 3;
 
     public ?int $sunset {
-        get => $this->getData(self::SUNSET_DATA_INDEX);
-        set => $this->setData(self::SUNSET_DATA_INDEX, $value);
+        get => $this->getData(self::SUNSET_INDEX);
+        set => $this->setData(self::SUNSET_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 4;
+    protected const int TYPE_INDEX = 4;
 
     public ?int $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/WeatherTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/WeatherTransfer.php
@@ -20,49 +20,45 @@ final class WeatherTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 4;
 
     protected const array META_DATA = [
-        self::DESCRIPTION => self::DESCRIPTION_DATA_NAME,
-        self::ICON => self::ICON_DATA_NAME,
-        self::ID => self::ID_DATA_NAME,
-        self::MAIN => self::MAIN_DATA_NAME,
+        self::DESCRIPTION_INDEX => self::DESCRIPTION,
+        self::ICON_INDEX => self::ICON,
+        self::ID_INDEX => self::ID,
+        self::MAIN_INDEX => self::MAIN,
     ];
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const string DESCRIPTION_DATA_NAME = 'DESCRIPTION';
-    protected const int DESCRIPTION_DATA_INDEX = 0;
+    protected const int DESCRIPTION_INDEX = 0;
 
     public ?string $description {
-        get => $this->getData(self::DESCRIPTION_DATA_INDEX);
-        set => $this->setData(self::DESCRIPTION_DATA_INDEX, $value);
+        get => $this->getData(self::DESCRIPTION_INDEX);
+        set => $this->setData(self::DESCRIPTION_INDEX, $value);
     }
 
     // icon
     public const string ICON = 'icon';
-    protected const string ICON_DATA_NAME = 'ICON';
-    protected const int ICON_DATA_INDEX = 1;
+    protected const int ICON_INDEX = 1;
 
     public ?string $icon {
-        get => $this->getData(self::ICON_DATA_INDEX);
-        set => $this->setData(self::ICON_DATA_INDEX, $value);
+        get => $this->getData(self::ICON_INDEX);
+        set => $this->setData(self::ICON_INDEX, $value);
     }
 
     // id
     public const string ID = 'id';
-    protected const string ID_DATA_NAME = 'ID';
-    protected const int ID_DATA_INDEX = 2;
+    protected const int ID_INDEX = 2;
 
     public ?int $id {
-        get => $this->getData(self::ID_DATA_INDEX);
-        set => $this->setData(self::ID_DATA_INDEX, $value);
+        get => $this->getData(self::ID_INDEX);
+        set => $this->setData(self::ID_INDEX, $value);
     }
 
     // main
     public const string MAIN = 'main';
-    protected const string MAIN_DATA_NAME = 'MAIN';
-    protected const int MAIN_DATA_INDEX = 3;
+    protected const int MAIN_INDEX = 3;
 
     public ?string $main {
-        get => $this->getData(self::MAIN_DATA_INDEX);
-        set => $this->setData(self::MAIN_DATA_INDEX, $value);
+        get => $this->getData(self::MAIN_INDEX);
+        set => $this->setData(self::MAIN_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/WindTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/WindTransfer.php
@@ -20,38 +20,35 @@ final class WindTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 3;
 
     protected const array META_DATA = [
-        self::DEG => self::DEG_DATA_NAME,
-        self::GUST => self::GUST_DATA_NAME,
-        self::SPEED => self::SPEED_DATA_NAME,
+        self::DEG_INDEX => self::DEG,
+        self::GUST_INDEX => self::GUST,
+        self::SPEED_INDEX => self::SPEED,
     ];
 
     // deg
     public const string DEG = 'deg';
-    protected const string DEG_DATA_NAME = 'DEG';
-    protected const int DEG_DATA_INDEX = 0;
+    protected const int DEG_INDEX = 0;
 
     public ?int $deg {
-        get => $this->getData(self::DEG_DATA_INDEX);
-        set => $this->setData(self::DEG_DATA_INDEX, $value);
+        get => $this->getData(self::DEG_INDEX);
+        set => $this->setData(self::DEG_INDEX, $value);
     }
 
     // gust
     public const string GUST = 'gust';
-    protected const string GUST_DATA_NAME = 'GUST';
-    protected const int GUST_DATA_INDEX = 1;
+    protected const int GUST_INDEX = 1;
 
     public ?float $gust {
-        get => $this->getData(self::GUST_DATA_INDEX);
-        set => $this->setData(self::GUST_DATA_INDEX, $value);
+        get => $this->getData(self::GUST_INDEX);
+        set => $this->setData(self::GUST_INDEX, $value);
     }
 
     // speed
     public const string SPEED = 'speed';
-    protected const string SPEED_DATA_NAME = 'SPEED';
-    protected const int SPEED_DATA_INDEX = 2;
+    protected const int SPEED_INDEX = 2;
 
     public ?float $speed {
-        get => $this->getData(self::SPEED_DATA_INDEX);
-        set => $this->setData(self::SPEED_DATA_INDEX, $value);
+        get => $this->getData(self::SPEED_INDEX);
+        set => $this->setData(self::SPEED_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/ArdNewsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/ArdNewsTransfer.php
@@ -23,64 +23,59 @@ final class ArdNewsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 5;
 
     protected const array META_DATA = [
-        self::NEW_STORIES_COUNT_LINK => self::NEW_STORIES_COUNT_LINK_DATA_NAME,
-        self::NEWS => self::NEWS_DATA_NAME,
-        self::NEXT_PAGE => self::NEXT_PAGE_DATA_NAME,
-        self::REGIONAL => self::REGIONAL_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::NEW_STORIES_COUNT_LINK_INDEX => self::NEW_STORIES_COUNT_LINK,
+        self::NEWS_INDEX => self::NEWS,
+        self::NEXT_PAGE_INDEX => self::NEXT_PAGE,
+        self::REGIONAL_INDEX => self::REGIONAL,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // newStoriesCountLink
     public const string NEW_STORIES_COUNT_LINK = 'newStoriesCountLink';
-    protected const string NEW_STORIES_COUNT_LINK_DATA_NAME = 'NEW_STORIES_COUNT_LINK';
-    protected const int NEW_STORIES_COUNT_LINK_DATA_INDEX = 0;
+    protected const int NEW_STORIES_COUNT_LINK_INDEX = 0;
 
     public ?string $newStoriesCountLink {
-        get => $this->getData(self::NEW_STORIES_COUNT_LINK_DATA_INDEX);
-        set => $this->setData(self::NEW_STORIES_COUNT_LINK_DATA_INDEX, $value);
+        get => $this->getData(self::NEW_STORIES_COUNT_LINK_INDEX);
+        set => $this->setData(self::NEW_STORIES_COUNT_LINK_INDEX, $value);
     }
 
     // news
     #[CollectionPropertyTypeAttribute(NewsTransfer::class)]
     public const string NEWS = 'news';
-    protected const string NEWS_DATA_NAME = 'NEWS';
-    protected const int NEWS_DATA_INDEX = 1;
+    protected const int NEWS_INDEX = 1;
 
     /** @var \ArrayObject<int,NewsTransfer> */
     public ArrayObject $news {
-        get => $this->getData(self::NEWS_DATA_INDEX);
-        set => $this->setData(self::NEWS_DATA_INDEX, $value);
+        get => $this->getData(self::NEWS_INDEX);
+        set => $this->setData(self::NEWS_INDEX, $value);
     }
 
     // nextPage
     public const string NEXT_PAGE = 'nextPage';
-    protected const string NEXT_PAGE_DATA_NAME = 'NEXT_PAGE';
-    protected const int NEXT_PAGE_DATA_INDEX = 2;
+    protected const int NEXT_PAGE_INDEX = 2;
 
     public ?string $nextPage {
-        get => $this->getData(self::NEXT_PAGE_DATA_INDEX);
-        set => $this->setData(self::NEXT_PAGE_DATA_INDEX, $value);
+        get => $this->getData(self::NEXT_PAGE_INDEX);
+        set => $this->setData(self::NEXT_PAGE_INDEX, $value);
     }
 
     // regional
     #[ArrayPropertyTypeAttribute]
     public const string REGIONAL = 'regional';
-    protected const string REGIONAL_DATA_NAME = 'REGIONAL';
-    protected const int REGIONAL_DATA_INDEX = 3;
+    protected const int REGIONAL_INDEX = 3;
 
     /** @var array<int|string,mixed> */
     public array $regional {
-        get => $this->getData(self::REGIONAL_DATA_INDEX);
-        set => $this->setData(self::REGIONAL_DATA_INDEX, $value);
+        get => $this->getData(self::REGIONAL_INDEX);
+        set => $this->setData(self::REGIONAL_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 4;
+    protected const int TYPE_INDEX = 4;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/BrandingImageTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/BrandingImageTransfer.php
@@ -21,61 +21,56 @@ final class BrandingImageTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 5;
 
     protected const array META_DATA = [
-        self::ALTTEXT => self::ALTTEXT_DATA_NAME,
-        self::COPYRIGHT => self::COPYRIGHT_DATA_NAME,
-        self::IMAGE_VARIANTS => self::IMAGE_VARIANTS_DATA_NAME,
-        self::TITLE => self::TITLE_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::ALTTEXT_INDEX => self::ALTTEXT,
+        self::COPYRIGHT_INDEX => self::COPYRIGHT,
+        self::IMAGE_VARIANTS_INDEX => self::IMAGE_VARIANTS,
+        self::TITLE_INDEX => self::TITLE,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // alttext
     public const string ALTTEXT = 'alttext';
-    protected const string ALTTEXT_DATA_NAME = 'ALTTEXT';
-    protected const int ALTTEXT_DATA_INDEX = 0;
+    protected const int ALTTEXT_INDEX = 0;
 
     public ?string $alttext {
-        get => $this->getData(self::ALTTEXT_DATA_INDEX);
-        set => $this->setData(self::ALTTEXT_DATA_INDEX, $value);
+        get => $this->getData(self::ALTTEXT_INDEX);
+        set => $this->setData(self::ALTTEXT_INDEX, $value);
     }
 
     // copyright
     public const string COPYRIGHT = 'copyright';
-    protected const string COPYRIGHT_DATA_NAME = 'COPYRIGHT';
-    protected const int COPYRIGHT_DATA_INDEX = 1;
+    protected const int COPYRIGHT_INDEX = 1;
 
     public ?string $copyright {
-        get => $this->getData(self::COPYRIGHT_DATA_INDEX);
-        set => $this->setData(self::COPYRIGHT_DATA_INDEX, $value);
+        get => $this->getData(self::COPYRIGHT_INDEX);
+        set => $this->setData(self::COPYRIGHT_INDEX, $value);
     }
 
     // imageVariants
     #[PropertyTypeAttribute(ImageVariantsTransfer::class)]
     public const string IMAGE_VARIANTS = 'imageVariants';
-    protected const string IMAGE_VARIANTS_DATA_NAME = 'IMAGE_VARIANTS';
-    protected const int IMAGE_VARIANTS_DATA_INDEX = 2;
+    protected const int IMAGE_VARIANTS_INDEX = 2;
 
     public ?ImageVariantsTransfer $imageVariants {
-        get => $this->getData(self::IMAGE_VARIANTS_DATA_INDEX);
-        set => $this->setData(self::IMAGE_VARIANTS_DATA_INDEX, $value);
+        get => $this->getData(self::IMAGE_VARIANTS_INDEX);
+        set => $this->setData(self::IMAGE_VARIANTS_INDEX, $value);
     }
 
     // title
     public const string TITLE = 'title';
-    protected const string TITLE_DATA_NAME = 'TITLE';
-    protected const int TITLE_DATA_INDEX = 3;
+    protected const int TITLE_INDEX = 3;
 
     public ?string $title {
-        get => $this->getData(self::TITLE_DATA_INDEX);
-        set => $this->setData(self::TITLE_DATA_INDEX, $value);
+        get => $this->getData(self::TITLE_INDEX);
+        set => $this->setData(self::TITLE_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 4;
+    protected const int TYPE_INDEX = 4;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/ImageVariantsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/ImageVariantsTransfer.php
@@ -20,16 +20,15 @@ final class ImageVariantsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::ORIGINAL => self::ORIGINAL_DATA_NAME,
+        self::ORIGINAL_INDEX => self::ORIGINAL,
     ];
 
     // original
     public const string ORIGINAL = 'original';
-    protected const string ORIGINAL_DATA_NAME = 'ORIGINAL';
-    protected const int ORIGINAL_DATA_INDEX = 0;
+    protected const int ORIGINAL_INDEX = 0;
 
     public ?string $original {
-        get => $this->getData(self::ORIGINAL_DATA_INDEX);
-        set => $this->setData(self::ORIGINAL_DATA_INDEX, $value);
+        get => $this->getData(self::ORIGINAL_INDEX);
+        set => $this->setData(self::ORIGINAL_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/NewsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/NewsTransfer.php
@@ -24,246 +24,225 @@ final class NewsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 21;
 
     protected const array META_DATA = [
-        self::BRANDING_IMAGE => self::BRANDING_IMAGE_DATA_NAME,
-        self::BREAKING_NEWS => self::BREAKING_NEWS_DATA_NAME,
-        self::COMMENTS => self::COMMENTS_DATA_NAME,
-        self::DATE => self::DATE_DATA_NAME,
-        self::DETAILS => self::DETAILS_DATA_NAME,
-        self::DETAILSWEB => self::DETAILSWEB_DATA_NAME,
-        self::EXTERNAL_ID => self::EXTERNAL_ID_DATA_NAME,
-        self::FIRST_SENTENCE => self::FIRST_SENTENCE_DATA_NAME,
-        self::GEOTAGS => self::GEOTAGS_DATA_NAME,
-        self::REGION_ID => self::REGION_ID_DATA_NAME,
-        self::REGION_IDS => self::REGION_IDS_DATA_NAME,
-        self::RESSORT => self::RESSORT_DATA_NAME,
-        self::SHARE_U_R_L => self::SHARE_U_R_L_DATA_NAME,
-        self::SOPHORA_ID => self::SOPHORA_ID_DATA_NAME,
-        self::TAGS => self::TAGS_DATA_NAME,
-        self::TEASER_IMAGE => self::TEASER_IMAGE_DATA_NAME,
-        self::TITLE => self::TITLE_DATA_NAME,
-        self::TOPLINE => self::TOPLINE_DATA_NAME,
-        self::TRACKING => self::TRACKING_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
-        self::UPDATE_CHECK_URL => self::UPDATE_CHECK_URL_DATA_NAME,
+        self::BRANDING_IMAGE_INDEX => self::BRANDING_IMAGE,
+        self::BREAKING_NEWS_INDEX => self::BREAKING_NEWS,
+        self::COMMENTS_INDEX => self::COMMENTS,
+        self::DATE_INDEX => self::DATE,
+        self::DETAILS_INDEX => self::DETAILS,
+        self::DETAILSWEB_INDEX => self::DETAILSWEB,
+        self::EXTERNAL_ID_INDEX => self::EXTERNAL_ID,
+        self::FIRST_SENTENCE_INDEX => self::FIRST_SENTENCE,
+        self::GEOTAGS_INDEX => self::GEOTAGS,
+        self::REGION_ID_INDEX => self::REGION_ID,
+        self::REGION_IDS_INDEX => self::REGION_IDS,
+        self::RESSORT_INDEX => self::RESSORT,
+        self::SHARE_U_R_L_INDEX => self::SHARE_U_R_L,
+        self::SOPHORA_ID_INDEX => self::SOPHORA_ID,
+        self::TAGS_INDEX => self::TAGS,
+        self::TEASER_IMAGE_INDEX => self::TEASER_IMAGE,
+        self::TITLE_INDEX => self::TITLE,
+        self::TOPLINE_INDEX => self::TOPLINE,
+        self::TRACKING_INDEX => self::TRACKING,
+        self::TYPE_INDEX => self::TYPE,
+        self::UPDATE_CHECK_URL_INDEX => self::UPDATE_CHECK_URL,
     ];
 
     // brandingImage
     #[PropertyTypeAttribute(BrandingImageTransfer::class)]
     public const string BRANDING_IMAGE = 'brandingImage';
-    protected const string BRANDING_IMAGE_DATA_NAME = 'BRANDING_IMAGE';
-    protected const int BRANDING_IMAGE_DATA_INDEX = 0;
+    protected const int BRANDING_IMAGE_INDEX = 0;
 
     public ?BrandingImageTransfer $brandingImage {
-        get => $this->getData(self::BRANDING_IMAGE_DATA_INDEX);
-        set => $this->setData(self::BRANDING_IMAGE_DATA_INDEX, $value);
+        get => $this->getData(self::BRANDING_IMAGE_INDEX);
+        set => $this->setData(self::BRANDING_IMAGE_INDEX, $value);
     }
 
     // breakingNews
     public const string BREAKING_NEWS = 'breakingNews';
-    protected const string BREAKING_NEWS_DATA_NAME = 'BREAKING_NEWS';
-    protected const int BREAKING_NEWS_DATA_INDEX = 1;
+    protected const int BREAKING_NEWS_INDEX = 1;
 
     public ?bool $breakingNews {
-        get => $this->getData(self::BREAKING_NEWS_DATA_INDEX);
-        set => $this->setData(self::BREAKING_NEWS_DATA_INDEX, $value);
+        get => $this->getData(self::BREAKING_NEWS_INDEX);
+        set => $this->setData(self::BREAKING_NEWS_INDEX, $value);
     }
 
     // comments
     public const string COMMENTS = 'comments';
-    protected const string COMMENTS_DATA_NAME = 'COMMENTS';
-    protected const int COMMENTS_DATA_INDEX = 2;
+    protected const int COMMENTS_INDEX = 2;
 
     public ?string $comments {
-        get => $this->getData(self::COMMENTS_DATA_INDEX);
-        set => $this->setData(self::COMMENTS_DATA_INDEX, $value);
+        get => $this->getData(self::COMMENTS_INDEX);
+        set => $this->setData(self::COMMENTS_INDEX, $value);
     }
 
     // date
     public const string DATE = 'date';
-    protected const string DATE_DATA_NAME = 'DATE';
-    protected const int DATE_DATA_INDEX = 3;
+    protected const int DATE_INDEX = 3;
 
     public ?string $date {
-        get => $this->getData(self::DATE_DATA_INDEX);
-        set => $this->setData(self::DATE_DATA_INDEX, $value);
+        get => $this->getData(self::DATE_INDEX);
+        set => $this->setData(self::DATE_INDEX, $value);
     }
 
     // details
     public const string DETAILS = 'details';
-    protected const string DETAILS_DATA_NAME = 'DETAILS';
-    protected const int DETAILS_DATA_INDEX = 4;
+    protected const int DETAILS_INDEX = 4;
 
     public ?string $details {
-        get => $this->getData(self::DETAILS_DATA_INDEX);
-        set => $this->setData(self::DETAILS_DATA_INDEX, $value);
+        get => $this->getData(self::DETAILS_INDEX);
+        set => $this->setData(self::DETAILS_INDEX, $value);
     }
 
     // detailsweb
     public const string DETAILSWEB = 'detailsweb';
-    protected const string DETAILSWEB_DATA_NAME = 'DETAILSWEB';
-    protected const int DETAILSWEB_DATA_INDEX = 5;
+    protected const int DETAILSWEB_INDEX = 5;
 
     public ?string $detailsweb {
-        get => $this->getData(self::DETAILSWEB_DATA_INDEX);
-        set => $this->setData(self::DETAILSWEB_DATA_INDEX, $value);
+        get => $this->getData(self::DETAILSWEB_INDEX);
+        set => $this->setData(self::DETAILSWEB_INDEX, $value);
     }
 
     // externalId
     public const string EXTERNAL_ID = 'externalId';
-    protected const string EXTERNAL_ID_DATA_NAME = 'EXTERNAL_ID';
-    protected const int EXTERNAL_ID_DATA_INDEX = 6;
+    protected const int EXTERNAL_ID_INDEX = 6;
 
     public ?string $externalId {
-        get => $this->getData(self::EXTERNAL_ID_DATA_INDEX);
-        set => $this->setData(self::EXTERNAL_ID_DATA_INDEX, $value);
+        get => $this->getData(self::EXTERNAL_ID_INDEX);
+        set => $this->setData(self::EXTERNAL_ID_INDEX, $value);
     }
 
     // firstSentence
     public const string FIRST_SENTENCE = 'firstSentence';
-    protected const string FIRST_SENTENCE_DATA_NAME = 'FIRST_SENTENCE';
-    protected const int FIRST_SENTENCE_DATA_INDEX = 7;
+    protected const int FIRST_SENTENCE_INDEX = 7;
 
     public ?string $firstSentence {
-        get => $this->getData(self::FIRST_SENTENCE_DATA_INDEX);
-        set => $this->setData(self::FIRST_SENTENCE_DATA_INDEX, $value);
+        get => $this->getData(self::FIRST_SENTENCE_INDEX);
+        set => $this->setData(self::FIRST_SENTENCE_INDEX, $value);
     }
 
     // geotags
     #[ArrayPropertyTypeAttribute]
     public const string GEOTAGS = 'geotags';
-    protected const string GEOTAGS_DATA_NAME = 'GEOTAGS';
-    protected const int GEOTAGS_DATA_INDEX = 8;
+    protected const int GEOTAGS_INDEX = 8;
 
     /** @var array<int|string,mixed> */
     public array $geotags {
-        get => $this->getData(self::GEOTAGS_DATA_INDEX);
-        set => $this->setData(self::GEOTAGS_DATA_INDEX, $value);
+        get => $this->getData(self::GEOTAGS_INDEX);
+        set => $this->setData(self::GEOTAGS_INDEX, $value);
     }
 
     // regionId
     public const string REGION_ID = 'regionId';
-    protected const string REGION_ID_DATA_NAME = 'REGION_ID';
-    protected const int REGION_ID_DATA_INDEX = 9;
+    protected const int REGION_ID_INDEX = 9;
 
     public ?int $regionId {
-        get => $this->getData(self::REGION_ID_DATA_INDEX);
-        set => $this->setData(self::REGION_ID_DATA_INDEX, $value);
+        get => $this->getData(self::REGION_ID_INDEX);
+        set => $this->setData(self::REGION_ID_INDEX, $value);
     }
 
     // regionIds
     #[ArrayPropertyTypeAttribute]
     public const string REGION_IDS = 'regionIds';
-    protected const string REGION_IDS_DATA_NAME = 'REGION_IDS';
-    protected const int REGION_IDS_DATA_INDEX = 10;
+    protected const int REGION_IDS_INDEX = 10;
 
     /** @var array<int|string,mixed> */
     public array $regionIds {
-        get => $this->getData(self::REGION_IDS_DATA_INDEX);
-        set => $this->setData(self::REGION_IDS_DATA_INDEX, $value);
+        get => $this->getData(self::REGION_IDS_INDEX);
+        set => $this->setData(self::REGION_IDS_INDEX, $value);
     }
 
     // ressort
     public const string RESSORT = 'ressort';
-    protected const string RESSORT_DATA_NAME = 'RESSORT';
-    protected const int RESSORT_DATA_INDEX = 11;
+    protected const int RESSORT_INDEX = 11;
 
     public ?string $ressort {
-        get => $this->getData(self::RESSORT_DATA_INDEX);
-        set => $this->setData(self::RESSORT_DATA_INDEX, $value);
+        get => $this->getData(self::RESSORT_INDEX);
+        set => $this->setData(self::RESSORT_INDEX, $value);
     }
 
     // shareURL
     public const string SHARE_U_R_L = 'shareURL';
-    protected const string SHARE_U_R_L_DATA_NAME = 'SHARE_U_R_L';
-    protected const int SHARE_U_R_L_DATA_INDEX = 12;
+    protected const int SHARE_U_R_L_INDEX = 12;
 
     public ?string $shareURL {
-        get => $this->getData(self::SHARE_U_R_L_DATA_INDEX);
-        set => $this->setData(self::SHARE_U_R_L_DATA_INDEX, $value);
+        get => $this->getData(self::SHARE_U_R_L_INDEX);
+        set => $this->setData(self::SHARE_U_R_L_INDEX, $value);
     }
 
     // sophoraId
     public const string SOPHORA_ID = 'sophoraId';
-    protected const string SOPHORA_ID_DATA_NAME = 'SOPHORA_ID';
-    protected const int SOPHORA_ID_DATA_INDEX = 13;
+    protected const int SOPHORA_ID_INDEX = 13;
 
     public ?string $sophoraId {
-        get => $this->getData(self::SOPHORA_ID_DATA_INDEX);
-        set => $this->setData(self::SOPHORA_ID_DATA_INDEX, $value);
+        get => $this->getData(self::SOPHORA_ID_INDEX);
+        set => $this->setData(self::SOPHORA_ID_INDEX, $value);
     }
 
     // tags
     #[CollectionPropertyTypeAttribute(TagsTransfer::class)]
     public const string TAGS = 'tags';
-    protected const string TAGS_DATA_NAME = 'TAGS';
-    protected const int TAGS_DATA_INDEX = 14;
+    protected const int TAGS_INDEX = 14;
 
     /** @var \ArrayObject<int,TagsTransfer> */
     public ArrayObject $tags {
-        get => $this->getData(self::TAGS_DATA_INDEX);
-        set => $this->setData(self::TAGS_DATA_INDEX, $value);
+        get => $this->getData(self::TAGS_INDEX);
+        set => $this->setData(self::TAGS_INDEX, $value);
     }
 
     // teaserImage
     #[PropertyTypeAttribute(TeaserImageTransfer::class)]
     public const string TEASER_IMAGE = 'teaserImage';
-    protected const string TEASER_IMAGE_DATA_NAME = 'TEASER_IMAGE';
-    protected const int TEASER_IMAGE_DATA_INDEX = 15;
+    protected const int TEASER_IMAGE_INDEX = 15;
 
     public ?TeaserImageTransfer $teaserImage {
-        get => $this->getData(self::TEASER_IMAGE_DATA_INDEX);
-        set => $this->setData(self::TEASER_IMAGE_DATA_INDEX, $value);
+        get => $this->getData(self::TEASER_IMAGE_INDEX);
+        set => $this->setData(self::TEASER_IMAGE_INDEX, $value);
     }
 
     // title
     public const string TITLE = 'title';
-    protected const string TITLE_DATA_NAME = 'TITLE';
-    protected const int TITLE_DATA_INDEX = 16;
+    protected const int TITLE_INDEX = 16;
 
     public ?string $title {
-        get => $this->getData(self::TITLE_DATA_INDEX);
-        set => $this->setData(self::TITLE_DATA_INDEX, $value);
+        get => $this->getData(self::TITLE_INDEX);
+        set => $this->setData(self::TITLE_INDEX, $value);
     }
 
     // topline
     public const string TOPLINE = 'topline';
-    protected const string TOPLINE_DATA_NAME = 'TOPLINE';
-    protected const int TOPLINE_DATA_INDEX = 17;
+    protected const int TOPLINE_INDEX = 17;
 
     public ?string $topline {
-        get => $this->getData(self::TOPLINE_DATA_INDEX);
-        set => $this->setData(self::TOPLINE_DATA_INDEX, $value);
+        get => $this->getData(self::TOPLINE_INDEX);
+        set => $this->setData(self::TOPLINE_INDEX, $value);
     }
 
     // tracking
     #[CollectionPropertyTypeAttribute(TrackingTransfer::class)]
     public const string TRACKING = 'tracking';
-    protected const string TRACKING_DATA_NAME = 'TRACKING';
-    protected const int TRACKING_DATA_INDEX = 18;
+    protected const int TRACKING_INDEX = 18;
 
     /** @var \ArrayObject<int,TrackingTransfer> */
     public ArrayObject $tracking {
-        get => $this->getData(self::TRACKING_DATA_INDEX);
-        set => $this->setData(self::TRACKING_DATA_INDEX, $value);
+        get => $this->getData(self::TRACKING_INDEX);
+        set => $this->setData(self::TRACKING_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 19;
+    protected const int TYPE_INDEX = 19;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 
     // updateCheckUrl
     public const string UPDATE_CHECK_URL = 'updateCheckUrl';
-    protected const string UPDATE_CHECK_URL_DATA_NAME = 'UPDATE_CHECK_URL';
-    protected const int UPDATE_CHECK_URL_DATA_INDEX = 20;
+    protected const int UPDATE_CHECK_URL_INDEX = 20;
 
     public ?string $updateCheckUrl {
-        get => $this->getData(self::UPDATE_CHECK_URL_DATA_INDEX);
-        set => $this->setData(self::UPDATE_CHECK_URL_DATA_INDEX, $value);
+        get => $this->getData(self::UPDATE_CHECK_URL_INDEX);
+        set => $this->setData(self::UPDATE_CHECK_URL_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TagsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TagsTransfer.php
@@ -20,16 +20,15 @@ final class TagsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::TAG => self::TAG_DATA_NAME,
+        self::TAG_INDEX => self::TAG,
     ];
 
     // tag
     public const string TAG = 'tag';
-    protected const string TAG_DATA_NAME = 'TAG';
-    protected const int TAG_DATA_INDEX = 0;
+    protected const int TAG_INDEX = 0;
 
     public ?string $tag {
-        get => $this->getData(self::TAG_DATA_INDEX);
-        set => $this->setData(self::TAG_DATA_INDEX, $value);
+        get => $this->getData(self::TAG_INDEX);
+        set => $this->setData(self::TAG_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TeaserImageTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TeaserImageTransfer.php
@@ -21,62 +21,57 @@ final class TeaserImageTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 5;
 
     protected const array META_DATA = [
-        self::ALTTEXT => self::ALTTEXT_DATA_NAME,
-        self::COPYRIGHT => self::COPYRIGHT_DATA_NAME,
-        self::IMAGE_VARIANTS => self::IMAGE_VARIANTS_DATA_NAME,
-        self::TITLE => self::TITLE_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::ALTTEXT_INDEX => self::ALTTEXT,
+        self::COPYRIGHT_INDEX => self::COPYRIGHT,
+        self::IMAGE_VARIANTS_INDEX => self::IMAGE_VARIANTS,
+        self::TITLE_INDEX => self::TITLE,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // alttext
     public const string ALTTEXT = 'alttext';
-    protected const string ALTTEXT_DATA_NAME = 'ALTTEXT';
-    protected const int ALTTEXT_DATA_INDEX = 0;
+    protected const int ALTTEXT_INDEX = 0;
 
     public ?string $alttext {
-        get => $this->getData(self::ALTTEXT_DATA_INDEX);
-        set => $this->setData(self::ALTTEXT_DATA_INDEX, $value);
+        get => $this->getData(self::ALTTEXT_INDEX);
+        set => $this->setData(self::ALTTEXT_INDEX, $value);
     }
 
     // copyright
     public const string COPYRIGHT = 'copyright';
-    protected const string COPYRIGHT_DATA_NAME = 'COPYRIGHT';
-    protected const int COPYRIGHT_DATA_INDEX = 1;
+    protected const int COPYRIGHT_INDEX = 1;
 
     public ?string $copyright {
-        get => $this->getData(self::COPYRIGHT_DATA_INDEX);
-        set => $this->setData(self::COPYRIGHT_DATA_INDEX, $value);
+        get => $this->getData(self::COPYRIGHT_INDEX);
+        set => $this->setData(self::COPYRIGHT_INDEX, $value);
     }
 
     // imageVariants
     #[ArrayPropertyTypeAttribute]
     public const string IMAGE_VARIANTS = 'imageVariants';
-    protected const string IMAGE_VARIANTS_DATA_NAME = 'IMAGE_VARIANTS';
-    protected const int IMAGE_VARIANTS_DATA_INDEX = 2;
+    protected const int IMAGE_VARIANTS_INDEX = 2;
 
     /** @var array<int|string,mixed> */
     public array $imageVariants {
-        get => $this->getData(self::IMAGE_VARIANTS_DATA_INDEX);
-        set => $this->setData(self::IMAGE_VARIANTS_DATA_INDEX, $value);
+        get => $this->getData(self::IMAGE_VARIANTS_INDEX);
+        set => $this->setData(self::IMAGE_VARIANTS_INDEX, $value);
     }
 
     // title
     public const string TITLE = 'title';
-    protected const string TITLE_DATA_NAME = 'TITLE';
-    protected const int TITLE_DATA_INDEX = 3;
+    protected const int TITLE_INDEX = 3;
 
     public ?string $title {
-        get => $this->getData(self::TITLE_DATA_INDEX);
-        set => $this->setData(self::TITLE_DATA_INDEX, $value);
+        get => $this->getData(self::TITLE_INDEX);
+        set => $this->setData(self::TITLE_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 4;
+    protected const int TYPE_INDEX = 4;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TrackingTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TrackingTransfer.php
@@ -20,115 +20,105 @@ final class TrackingTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 10;
 
     protected const array META_DATA = [
-        self::AV_FULL_SHOW => self::AV_FULL_SHOW_DATA_NAME,
-        self::BCR => self::BCR_DATA_NAME,
-        self::CID => self::CID_DATA_NAME,
-        self::CTP => self::CTP_DATA_NAME,
-        self::OTP => self::OTP_DATA_NAME,
-        self::PDT => self::PDT_DATA_NAME,
-        self::PTI => self::PTI_DATA_NAME,
-        self::SID => self::SID_DATA_NAME,
-        self::SRC => self::SRC_DATA_NAME,
-        self::TYPE => self::TYPE_DATA_NAME,
+        self::AV_FULL_SHOW_INDEX => self::AV_FULL_SHOW,
+        self::BCR_INDEX => self::BCR,
+        self::CID_INDEX => self::CID,
+        self::CTP_INDEX => self::CTP,
+        self::OTP_INDEX => self::OTP,
+        self::PDT_INDEX => self::PDT,
+        self::PTI_INDEX => self::PTI,
+        self::SID_INDEX => self::SID,
+        self::SRC_INDEX => self::SRC,
+        self::TYPE_INDEX => self::TYPE,
     ];
 
     // av_full_show
     public const string AV_FULL_SHOW = 'av_full_show';
-    protected const string AV_FULL_SHOW_DATA_NAME = 'AV_FULL_SHOW';
-    protected const int AV_FULL_SHOW_DATA_INDEX = 0;
+    protected const int AV_FULL_SHOW_INDEX = 0;
 
     public ?bool $av_full_show {
-        get => $this->getData(self::AV_FULL_SHOW_DATA_INDEX);
-        set => $this->setData(self::AV_FULL_SHOW_DATA_INDEX, $value);
+        get => $this->getData(self::AV_FULL_SHOW_INDEX);
+        set => $this->setData(self::AV_FULL_SHOW_INDEX, $value);
     }
 
     // bcr
     public const string BCR = 'bcr';
-    protected const string BCR_DATA_NAME = 'BCR';
-    protected const int BCR_DATA_INDEX = 1;
+    protected const int BCR_INDEX = 1;
 
     public ?string $bcr {
-        get => $this->getData(self::BCR_DATA_INDEX);
-        set => $this->setData(self::BCR_DATA_INDEX, $value);
+        get => $this->getData(self::BCR_INDEX);
+        set => $this->setData(self::BCR_INDEX, $value);
     }
 
     // cid
     public const string CID = 'cid';
-    protected const string CID_DATA_NAME = 'CID';
-    protected const int CID_DATA_INDEX = 2;
+    protected const int CID_INDEX = 2;
 
     public ?string $cid {
-        get => $this->getData(self::CID_DATA_INDEX);
-        set => $this->setData(self::CID_DATA_INDEX, $value);
+        get => $this->getData(self::CID_INDEX);
+        set => $this->setData(self::CID_INDEX, $value);
     }
 
     // ctp
     public const string CTP = 'ctp';
-    protected const string CTP_DATA_NAME = 'CTP';
-    protected const int CTP_DATA_INDEX = 3;
+    protected const int CTP_INDEX = 3;
 
     public ?string $ctp {
-        get => $this->getData(self::CTP_DATA_INDEX);
-        set => $this->setData(self::CTP_DATA_INDEX, $value);
+        get => $this->getData(self::CTP_INDEX);
+        set => $this->setData(self::CTP_INDEX, $value);
     }
 
     // otp
     public const string OTP = 'otp';
-    protected const string OTP_DATA_NAME = 'OTP';
-    protected const int OTP_DATA_INDEX = 4;
+    protected const int OTP_INDEX = 4;
 
     public ?string $otp {
-        get => $this->getData(self::OTP_DATA_INDEX);
-        set => $this->setData(self::OTP_DATA_INDEX, $value);
+        get => $this->getData(self::OTP_INDEX);
+        set => $this->setData(self::OTP_INDEX, $value);
     }
 
     // pdt
     public const string PDT = 'pdt';
-    protected const string PDT_DATA_NAME = 'PDT';
-    protected const int PDT_DATA_INDEX = 5;
+    protected const int PDT_INDEX = 5;
 
     public ?string $pdt {
-        get => $this->getData(self::PDT_DATA_INDEX);
-        set => $this->setData(self::PDT_DATA_INDEX, $value);
+        get => $this->getData(self::PDT_INDEX);
+        set => $this->setData(self::PDT_INDEX, $value);
     }
 
     // pti
     public const string PTI = 'pti';
-    protected const string PTI_DATA_NAME = 'PTI';
-    protected const int PTI_DATA_INDEX = 6;
+    protected const int PTI_INDEX = 6;
 
     public ?string $pti {
-        get => $this->getData(self::PTI_DATA_INDEX);
-        set => $this->setData(self::PTI_DATA_INDEX, $value);
+        get => $this->getData(self::PTI_INDEX);
+        set => $this->setData(self::PTI_INDEX, $value);
     }
 
     // sid
     public const string SID = 'sid';
-    protected const string SID_DATA_NAME = 'SID';
-    protected const int SID_DATA_INDEX = 7;
+    protected const int SID_INDEX = 7;
 
     public ?string $sid {
-        get => $this->getData(self::SID_DATA_INDEX);
-        set => $this->setData(self::SID_DATA_INDEX, $value);
+        get => $this->getData(self::SID_INDEX);
+        set => $this->setData(self::SID_INDEX, $value);
     }
 
     // src
     public const string SRC = 'src';
-    protected const string SRC_DATA_NAME = 'SRC';
-    protected const int SRC_DATA_INDEX = 8;
+    protected const int SRC_INDEX = 8;
 
     public ?string $src {
-        get => $this->getData(self::SRC_DATA_INDEX);
-        set => $this->setData(self::SRC_DATA_INDEX, $value);
+        get => $this->getData(self::SRC_INDEX);
+        set => $this->setData(self::SRC_INDEX, $value);
     }
 
     // type
     public const string TYPE = 'type';
-    protected const string TYPE_DATA_NAME = 'TYPE';
-    protected const int TYPE_DATA_INDEX = 9;
+    protected const int TYPE_INDEX = 9;
 
     public ?string $type {
-        get => $this->getData(self::TYPE_DATA_INDEX);
-        set => $this->setData(self::TYPE_DATA_INDEX, $value);
+        get => $this->getData(self::TYPE_INDEX);
+        set => $this->setData(self::TYPE_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Advanced/BookAuthorData.php
+++ b/tests/integration/Transfer/Advanced/BookAuthorData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picamator\Tests\Integration\TransferObject\Transfer\Advanced;
+
+use Picamator\TransferObject\Transfer\TransferAdapterTrait;
+use Picamator\TransferObject\Transfer\TransferInterface;
+
+class BookAuthorData implements TransferInterface
+{
+    use TransferAdapterTrait;
+
+    public string $firstName;
+
+    public string $lastName;
+}

--- a/tests/integration/Transfer/DummyTransferAdapterTest.php
+++ b/tests/integration/Transfer/DummyTransferAdapterTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Picamator\Tests\Integration\TransferObject\Transfer;
 
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BookmarkData;
 
 #[Group('transfer')]
-#[IgnoreDeprecations]
 class DummyTransferAdapterTest extends TestCase
 {
     private BookmarkData $bookmarkData;
@@ -30,15 +28,6 @@ class DummyTransferAdapterTest extends TestCase
 
         // Act
         $actual = $bookmarkData->toArray();
-
-        // Assert
-        $this->assertSame([], $actual);
-    }
-
-    public function testToFilterArray(): void
-    {
-        // Act
-        $actual = $this->bookmarkData->toFilterArray();
 
         // Assert
         $this->assertSame([], $actual);

--- a/tests/integration/Transfer/Generated/AuthorTransfer.php
+++ b/tests/integration/Transfer/Generated/AuthorTransfer.php
@@ -20,27 +20,25 @@ final class AuthorTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::FIRST_NAME => self::FIRST_NAME_DATA_NAME,
-        self::LAST_NAME => self::LAST_NAME_DATA_NAME,
+        self::FIRST_NAME_INDEX => self::FIRST_NAME,
+        self::LAST_NAME_INDEX => self::LAST_NAME,
     ];
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const string FIRST_NAME_DATA_NAME = 'FIRST_NAME';
-    protected const int FIRST_NAME_DATA_INDEX = 0;
+    protected const int FIRST_NAME_INDEX = 0;
 
     public string $firstName {
-        get => $this->getData(self::FIRST_NAME_DATA_INDEX);
-        set => $this->setData(self::FIRST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FIRST_NAME_INDEX);
+        set => $this->setData(self::FIRST_NAME_INDEX, $value);
     }
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const string LAST_NAME_DATA_NAME = 'LAST_NAME';
-    protected const int LAST_NAME_DATA_INDEX = 1;
+    protected const int LAST_NAME_INDEX = 1;
 
     public string $lastName {
-        get => $this->getData(self::LAST_NAME_DATA_INDEX);
-        set => $this->setData(self::LAST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::LAST_NAME_INDEX);
+        set => $this->setData(self::LAST_NAME_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/BcMath/BcMathNumberTransfer.php
+++ b/tests/integration/Transfer/Generated/BcMath/BcMathNumberTransfer.php
@@ -22,17 +22,16 @@ final class BcMathNumberTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::I_AM_NUMBER => self::I_AM_NUMBER_DATA_NAME,
+        self::I_AM_NUMBER_INDEX => self::I_AM_NUMBER,
     ];
 
     // iAmNumber
     #[NumberPropertyTypeAttribute(Number::class)]
     public const string I_AM_NUMBER = 'iAmNumber';
-    protected const string I_AM_NUMBER_DATA_NAME = 'I_AM_NUMBER';
-    protected const int I_AM_NUMBER_DATA_INDEX = 0;
+    protected const int I_AM_NUMBER_INDEX = 0;
 
     public ?Number $iAmNumber {
-        get => $this->getData(self::I_AM_NUMBER_DATA_INDEX);
-        set => $this->setData(self::I_AM_NUMBER_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_NUMBER_INDEX);
+        set => $this->setData(self::I_AM_NUMBER_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/BookTransfer.php
+++ b/tests/integration/Transfer/Generated/BookTransfer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picamator\Tests\Integration\TransferObject\Transfer\Generated;
+
+use ArrayObject;
+use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BookData;
+use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BookmarkData;
+use Picamator\TransferObject\Transfer\AbstractTransfer;
+use Picamator\TransferObject\Transfer\Attribute\CollectionPropertyTypeAttribute;
+use Picamator\TransferObject\Transfer\Attribute\PropertyTypeAttribute;
+use Picamator\TransferObject\Transfer\TransferInterface;
+
+/**
+ * Specification:
+ * - Class is automatically generated based on a definition file.
+ * - To modify it, please update the corresponding definition file and run the generator again.
+ *
+ * Note: Do not manually edit this file, as changes will be overwritten.
+ *
+ * @see /tests/integration/Transfer/data/config/definition/book-advanced.transfer.yml Definition file path.
+ */
+final class BookTransfer extends AbstractTransfer
+{
+    protected const int META_DATA_SIZE = 2;
+
+    protected const array META_DATA = [
+        self::BOOKMARKS_INDEX => self::BOOKMARKS,
+        self::DATA_INDEX => self::DATA,
+    ];
+
+    // bookmarks
+    #[CollectionPropertyTypeAttribute(BookmarkData::class)]
+    public const string BOOKMARKS = 'bookmarks';
+    protected const int BOOKMARKS_INDEX = 0;
+
+    /** @var \ArrayObject<int,TransferInterface&BookmarkData> */
+    public ArrayObject $bookmarks {
+        get => $this->getData(self::BOOKMARKS_INDEX);
+        set => $this->setData(self::BOOKMARKS_INDEX, $value);
+    }
+
+    // data
+    #[PropertyTypeAttribute(BookData::class)]
+    public const string DATA = 'data';
+    protected const int DATA_INDEX = 1;
+
+    public TransferInterface&BookData $data {
+        get => $this->getData(self::DATA_INDEX);
+        set => $this->setData(self::DATA_INDEX, $value);
+    }
+}

--- a/tests/integration/Transfer/Generated/ItemCollectionTransfer.php
+++ b/tests/integration/Transfer/Generated/ItemCollectionTransfer.php
@@ -23,30 +23,28 @@ final class ItemCollectionTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ITEM => self::ITEM_DATA_NAME,
-        self::ITEMS => self::ITEMS_DATA_NAME,
+        self::ITEM_INDEX => self::ITEM,
+        self::ITEMS_INDEX => self::ITEMS,
     ];
 
     // item
     #[PropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEM = 'item';
-    protected const string ITEM_DATA_NAME = 'ITEM';
-    protected const int ITEM_DATA_INDEX = 0;
+    protected const int ITEM_INDEX = 0;
 
     public ?ItemTransfer $item {
-        get => $this->getData(self::ITEM_DATA_INDEX);
-        set => $this->setData(self::ITEM_DATA_INDEX, $value);
+        get => $this->getData(self::ITEM_INDEX);
+        set => $this->setData(self::ITEM_INDEX, $value);
     }
 
     // items
     #[CollectionPropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEMS = 'items';
-    protected const string ITEMS_DATA_NAME = 'ITEMS';
-    protected const int ITEMS_DATA_INDEX = 1;
+    protected const int ITEMS_INDEX = 1;
 
     /** @var \ArrayObject<int,ItemTransfer> */
     public ArrayObject $items {
-        get => $this->getData(self::ITEMS_DATA_INDEX);
-        set => $this->setData(self::ITEMS_DATA_INDEX, $value);
+        get => $this->getData(self::ITEMS_INDEX);
+        set => $this->setData(self::ITEMS_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/ItemTransfer.php
+++ b/tests/integration/Transfer/Generated/ItemTransfer.php
@@ -28,133 +28,122 @@ final class ItemTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 11;
 
     protected const array META_DATA = [
-        self::I_AM_ARRAY => self::I_AM_ARRAY_DATA_NAME,
-        self::I_AM_ARRAY_OBJECT => self::I_AM_ARRAY_OBJECT_DATA_NAME,
-        self::I_AM_BOOL => self::I_AM_BOOL_DATA_NAME,
-        self::I_AM_DATE_TIME => self::I_AM_DATE_TIME_DATA_NAME,
-        self::I_AM_DATE_TIME_IMMUTABLE => self::I_AM_DATE_TIME_IMMUTABLE_DATA_NAME,
-        self::I_AM_ENUM => self::I_AM_ENUM_DATA_NAME,
-        self::I_AM_FALSE => self::I_AM_FALSE_DATA_NAME,
-        self::I_AM_FLOAT => self::I_AM_FLOAT_DATA_NAME,
-        self::I_AM_INT => self::I_AM_INT_DATA_NAME,
-        self::I_AM_STRING => self::I_AM_STRING_DATA_NAME,
-        self::I_AM_TRUE => self::I_AM_TRUE_DATA_NAME,
+        self::I_AM_ARRAY_INDEX => self::I_AM_ARRAY,
+        self::I_AM_ARRAY_OBJECT_INDEX => self::I_AM_ARRAY_OBJECT,
+        self::I_AM_BOOL_INDEX => self::I_AM_BOOL,
+        self::I_AM_DATE_TIME_INDEX => self::I_AM_DATE_TIME,
+        self::I_AM_DATE_TIME_IMMUTABLE_INDEX => self::I_AM_DATE_TIME_IMMUTABLE,
+        self::I_AM_ENUM_INDEX => self::I_AM_ENUM,
+        self::I_AM_FALSE_INDEX => self::I_AM_FALSE,
+        self::I_AM_FLOAT_INDEX => self::I_AM_FLOAT,
+        self::I_AM_INT_INDEX => self::I_AM_INT,
+        self::I_AM_STRING_INDEX => self::I_AM_STRING,
+        self::I_AM_TRUE_INDEX => self::I_AM_TRUE,
     ];
 
     // iAmArray
     #[ArrayPropertyTypeAttribute]
     public const string I_AM_ARRAY = 'iAmArray';
-    protected const string I_AM_ARRAY_DATA_NAME = 'I_AM_ARRAY';
-    protected const int I_AM_ARRAY_DATA_INDEX = 0;
+    protected const int I_AM_ARRAY_INDEX = 0;
 
     /** @var array<int|string,mixed> */
     public array $iAmArray {
-        get => $this->getData(self::I_AM_ARRAY_DATA_INDEX);
-        set => $this->setData(self::I_AM_ARRAY_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_ARRAY_INDEX);
+        set => $this->setData(self::I_AM_ARRAY_INDEX, $value);
     }
 
     // iAmArrayObject
     #[ArrayObjectPropertyTypeAttribute]
     public const string I_AM_ARRAY_OBJECT = 'iAmArrayObject';
-    protected const string I_AM_ARRAY_OBJECT_DATA_NAME = 'I_AM_ARRAY_OBJECT';
-    protected const int I_AM_ARRAY_OBJECT_DATA_INDEX = 1;
+    protected const int I_AM_ARRAY_OBJECT_INDEX = 1;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $iAmArrayObject {
-        get => $this->getData(self::I_AM_ARRAY_OBJECT_DATA_INDEX);
-        set => $this->setData(self::I_AM_ARRAY_OBJECT_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_ARRAY_OBJECT_INDEX);
+        set => $this->setData(self::I_AM_ARRAY_OBJECT_INDEX, $value);
     }
 
     // iAmBool
     public const string I_AM_BOOL = 'iAmBool';
-    protected const string I_AM_BOOL_DATA_NAME = 'I_AM_BOOL';
-    protected const int I_AM_BOOL_DATA_INDEX = 2;
+    protected const int I_AM_BOOL_INDEX = 2;
 
     public ?bool $iAmBool {
-        get => $this->getData(self::I_AM_BOOL_DATA_INDEX);
-        set => $this->setData(self::I_AM_BOOL_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_BOOL_INDEX);
+        set => $this->setData(self::I_AM_BOOL_INDEX, $value);
     }
 
     // iAmDateTime
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string I_AM_DATE_TIME = 'iAmDateTime';
-    protected const string I_AM_DATE_TIME_DATA_NAME = 'I_AM_DATE_TIME';
-    protected const int I_AM_DATE_TIME_DATA_INDEX = 3;
+    protected const int I_AM_DATE_TIME_INDEX = 3;
 
     public ?DateTime $iAmDateTime {
-        get => $this->getData(self::I_AM_DATE_TIME_DATA_INDEX);
-        set => $this->setData(self::I_AM_DATE_TIME_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_DATE_TIME_INDEX);
+        set => $this->setData(self::I_AM_DATE_TIME_INDEX, $value);
     }
 
     // iAmDateTimeImmutable
     #[DateTimePropertyTypeAttribute(DateTimeImmutable::class)]
     public const string I_AM_DATE_TIME_IMMUTABLE = 'iAmDateTimeImmutable';
-    protected const string I_AM_DATE_TIME_IMMUTABLE_DATA_NAME = 'I_AM_DATE_TIME_IMMUTABLE';
-    protected const int I_AM_DATE_TIME_IMMUTABLE_DATA_INDEX = 4;
+    protected const int I_AM_DATE_TIME_IMMUTABLE_INDEX = 4;
 
     public ?DateTimeImmutable $iAmDateTimeImmutable {
-        get => $this->getData(self::I_AM_DATE_TIME_IMMUTABLE_DATA_INDEX);
-        set => $this->setData(self::I_AM_DATE_TIME_IMMUTABLE_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_DATE_TIME_IMMUTABLE_INDEX);
+        set => $this->setData(self::I_AM_DATE_TIME_IMMUTABLE_INDEX, $value);
     }
 
     // iAmEnum
     #[EnumPropertyTypeAttribute(ImBackedEnum::class)]
     public const string I_AM_ENUM = 'iAmEnum';
-    protected const string I_AM_ENUM_DATA_NAME = 'I_AM_ENUM';
-    protected const int I_AM_ENUM_DATA_INDEX = 5;
+    protected const int I_AM_ENUM_INDEX = 5;
 
     public ?ImBackedEnum $iAmEnum {
-        get => $this->getData(self::I_AM_ENUM_DATA_INDEX);
-        set => $this->setData(self::I_AM_ENUM_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_ENUM_INDEX);
+        set => $this->setData(self::I_AM_ENUM_INDEX, $value);
     }
 
     // iAmFalse
     public const string I_AM_FALSE = 'iAmFalse';
-    protected const string I_AM_FALSE_DATA_NAME = 'I_AM_FALSE';
-    protected const int I_AM_FALSE_DATA_INDEX = 6;
+    protected const int I_AM_FALSE_INDEX = 6;
 
     public ?false $iAmFalse {
-        get => $this->getData(self::I_AM_FALSE_DATA_INDEX);
-        set => $this->setData(self::I_AM_FALSE_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_FALSE_INDEX);
+        set => $this->setData(self::I_AM_FALSE_INDEX, $value);
     }
 
     // iAmFloat
     public const string I_AM_FLOAT = 'iAmFloat';
-    protected const string I_AM_FLOAT_DATA_NAME = 'I_AM_FLOAT';
-    protected const int I_AM_FLOAT_DATA_INDEX = 7;
+    protected const int I_AM_FLOAT_INDEX = 7;
 
     public ?float $iAmFloat {
-        get => $this->getData(self::I_AM_FLOAT_DATA_INDEX);
-        set => $this->setData(self::I_AM_FLOAT_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_FLOAT_INDEX);
+        set => $this->setData(self::I_AM_FLOAT_INDEX, $value);
     }
 
     // iAmInt
     public const string I_AM_INT = 'iAmInt';
-    protected const string I_AM_INT_DATA_NAME = 'I_AM_INT';
-    protected const int I_AM_INT_DATA_INDEX = 8;
+    protected const int I_AM_INT_INDEX = 8;
 
     public ?int $iAmInt {
-        get => $this->getData(self::I_AM_INT_DATA_INDEX);
-        set => $this->setData(self::I_AM_INT_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_INT_INDEX);
+        set => $this->setData(self::I_AM_INT_INDEX, $value);
     }
 
     // iAmString
     public const string I_AM_STRING = 'iAmString';
-    protected const string I_AM_STRING_DATA_NAME = 'I_AM_STRING';
-    protected const int I_AM_STRING_DATA_INDEX = 9;
+    protected const int I_AM_STRING_INDEX = 9;
 
     public ?string $iAmString {
-        get => $this->getData(self::I_AM_STRING_DATA_INDEX);
-        set => $this->setData(self::I_AM_STRING_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_STRING_INDEX);
+        set => $this->setData(self::I_AM_STRING_INDEX, $value);
     }
 
     // iAmTrue
     public const string I_AM_TRUE = 'iAmTrue';
-    protected const string I_AM_TRUE_DATA_NAME = 'I_AM_TRUE';
-    protected const int I_AM_TRUE_DATA_INDEX = 10;
+    protected const int I_AM_TRUE_INDEX = 10;
 
     public ?true $iAmTrue {
-        get => $this->getData(self::I_AM_TRUE_DATA_INDEX);
-        set => $this->setData(self::I_AM_TRUE_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_TRUE_INDEX);
+        set => $this->setData(self::I_AM_TRUE_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/NamespaceTransfer.php
+++ b/tests/integration/Transfer/Generated/NamespaceTransfer.php
@@ -26,30 +26,28 @@ final class NamespaceTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ITEMS => self::ITEMS_DATA_NAME,
-        self::REQUIRED => self::REQUIRED_DATA_NAME,
+        self::ITEMS_INDEX => self::ITEMS,
+        self::REQUIRED_INDEX => self::REQUIRED,
     ];
 
     // items
     #[CollectionPropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEMS = 'items';
-    protected const string ITEMS_DATA_NAME = 'ITEMS';
-    protected const int ITEMS_DATA_INDEX = 0;
+    protected const int ITEMS_INDEX = 0;
 
     /** @var \ArrayObject<int,TransferInterface&ItemTransfer> */
     public ArrayObject $items {
-        get => $this->getData(self::ITEMS_DATA_INDEX);
-        set => $this->setData(self::ITEMS_DATA_INDEX, $value);
+        get => $this->getData(self::ITEMS_INDEX);
+        set => $this->setData(self::ITEMS_INDEX, $value);
     }
 
     // required
     #[PropertyTypeAttribute(RequiredAlias::class)]
     public const string REQUIRED = 'required';
-    protected const string REQUIRED_DATA_NAME = 'REQUIRED';
-    protected const int REQUIRED_DATA_INDEX = 1;
+    protected const int REQUIRED_INDEX = 1;
 
     public TransferInterface&RequiredAlias $required {
-        get => $this->getData(self::REQUIRED_DATA_INDEX);
-        set => $this->setData(self::REQUIRED_DATA_INDEX, $value);
+        get => $this->getData(self::REQUIRED_INDEX);
+        set => $this->setData(self::REQUIRED_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/ProtectedTransfer.php
+++ b/tests/integration/Transfer/Generated/ProtectedTransfer.php
@@ -20,16 +20,15 @@ final class ProtectedTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::I_AM_PROTECTED => self::I_AM_PROTECTED_DATA_NAME,
+        self::I_AM_PROTECTED_INDEX => self::I_AM_PROTECTED,
     ];
 
     // iAmProtected
     public const string I_AM_PROTECTED = 'iAmProtected';
-    protected const string I_AM_PROTECTED_DATA_NAME = 'I_AM_PROTECTED';
-    protected const int I_AM_PROTECTED_DATA_INDEX = 0;
+    protected const int I_AM_PROTECTED_INDEX = 0;
 
     public protected(set) ?string $iAmProtected {
-        get => $this->getData(self::I_AM_PROTECTED_DATA_INDEX);
-        set => $this->setData(self::I_AM_PROTECTED_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_PROTECTED_INDEX);
+        set => $this->setData(self::I_AM_PROTECTED_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/Generated/RequiredTransfer.php
+++ b/tests/integration/Transfer/Generated/RequiredTransfer.php
@@ -20,16 +20,15 @@ final class RequiredTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 1;
 
     protected const array META_DATA = [
-        self::I_AM_REQUIRED => self::I_AM_REQUIRED_DATA_NAME,
+        self::I_AM_REQUIRED_INDEX => self::I_AM_REQUIRED,
     ];
 
     // iAmRequired
     public const string I_AM_REQUIRED = 'iAmRequired';
-    protected const string I_AM_REQUIRED_DATA_NAME = 'I_AM_REQUIRED';
-    protected const int I_AM_REQUIRED_DATA_INDEX = 0;
+    protected const int I_AM_REQUIRED_INDEX = 0;
 
     public string $iAmRequired {
-        get => $this->getData(self::I_AM_REQUIRED_DATA_INDEX);
-        set => $this->setData(self::I_AM_REQUIRED_DATA_INDEX, $value);
+        get => $this->getData(self::I_AM_REQUIRED_INDEX);
+        set => $this->setData(self::I_AM_REQUIRED_INDEX, $value);
     }
 }

--- a/tests/integration/Transfer/TransferAdapterTest.php
+++ b/tests/integration/Transfer/TransferAdapterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Picamator\Tests\Integration\TransferObject\Transfer;
 
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BcMathBookData;
@@ -14,7 +13,6 @@ use Picamator\Tests\Integration\TransferObject\Transfer\Enum\CountryEnum;
 use Picamator\Tests\Integration\TransferObject\Transfer\Generated\AuthorTransfer;
 
 #[Group('transfer')]
-#[IgnoreDeprecations]
 class TransferAdapterTest extends TestCase
 {
     public function testFromArrayToArray(): void
@@ -45,19 +43,6 @@ class TransferAdapterTest extends TestCase
 
         // Act
         $actual = $bookData->toArray();
-
-        // Assert
-        $this->assertSame($expected, $actual);
-    }
-
-    public function testToFilterArray(): void
-    {
-        // Arrange
-        $bookData = new BookData();
-        $expected = ['bookmarkPage' => 1];
-
-        // Act
-        $actual = $bookData->toFilterArray();
 
         // Assert
         $this->assertSame($expected, $actual);

--- a/tests/integration/Transfer/TransferAdapterTest.php
+++ b/tests/integration/Transfer/TransferAdapterTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BcMathBookData;
+use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BookAuthorData;
 use Picamator\Tests\Integration\TransferObject\Transfer\Advanced\BookData;
 use Picamator\Tests\Integration\TransferObject\Transfer\Enum\CountryEnum;
 use Picamator\Tests\Integration\TransferObject\Transfer\Generated\AuthorTransfer;
@@ -48,6 +49,21 @@ class TransferAdapterTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testFromArrayOnPartlyInitializedProperties(): void
+    {
+        // Arrange
+        $expected = ['lastName' => 'Kowalski'];
+
+        $bookAuthorData = new BookAuthorData();
+        $bookAuthorData->lastName = 'Kowalski';
+
+        // Act
+        $actual = $bookAuthorData->toArray();
+
+        // Assert
+        $this->assertSame($expected, $actual);
+    }
+
     public function testCount(): void
     {
         // Arrange
@@ -69,6 +85,21 @@ class TransferAdapterTest extends TestCase
 
         // Act
         $actual = iterator_to_array($bookData);
+
+        // Assert
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testIteratorOnPartlyInitializedProperties(): void
+    {
+        // Arrange
+        $expected = ['firstName' => 'Jan'];
+
+        $bookAuthorData = new BookAuthorData();
+        $bookAuthorData->firstName = 'Jan';
+
+        // Act
+        $actual = iterator_to_array($bookAuthorData);
 
         // Assert
         $this->assertSame($expected, $actual);

--- a/tests/integration/Transfer/TransferTest.php
+++ b/tests/integration/Transfer/TransferTest.php
@@ -20,7 +20,7 @@ use Picamator\Tests\Integration\TransferObject\Transfer\Generated\ItemTransfer;
 use Picamator\Tests\Integration\TransferObject\Transfer\Generated\NamespaceTransfer;
 use Picamator\Tests\Integration\TransferObject\Transfer\Generated\ProtectedTransfer;
 use Picamator\Tests\Integration\TransferObject\Transfer\Generated\RequiredTransfer;
-use Picamator\TransferObject\Transfer\Exception\PropertyTypeTransferException;
+use Picamator\TransferObject\Transfer\Exception\DataAssertTransferException;
 use ReflectionProperty;
 use TypeError;
 
@@ -245,7 +245,7 @@ class TransferTest extends TestCase
         $itemTransfer = new ItemTransfer();
 
         // Expect
-        $this->expectException(PropertyTypeTransferException::class);
+        $this->expectException(DataAssertTransferException::class);
 
         // Act
         $itemTransfer->fromArray($data);
@@ -279,7 +279,7 @@ class TransferTest extends TestCase
         $itemCollectionTransfer = new ItemCollectionTransfer();
 
         // Expect
-        $this->expectException(PropertyTypeTransferException::class);
+        $this->expectException(DataAssertTransferException::class);
 
         // Act
         $itemCollectionTransfer->fromArray($data);

--- a/tests/integration/Transfer/TransferTest.php
+++ b/tests/integration/Transfer/TransferTest.php
@@ -147,6 +147,16 @@ class TransferTest extends TestCase
                 ItemCollectionTransfer::ITEM => null,
             ],
         ];
+
+        yield 'data does not have any matched to transfer object properties' => [
+            [
+                'some-property' => 'some-value',
+            ],
+            [
+                ItemCollectionTransfer::ITEMS => [],
+                ItemCollectionTransfer::ITEM => null,
+            ],
+        ];
     }
 
     public function testSerialize(): void

--- a/tests/integration/Transfer/TransferTest.php
+++ b/tests/integration/Transfer/TransferTest.php
@@ -229,7 +229,8 @@ class TransferTest extends TestCase
         $this->expectException(TypeError::class);
 
         // Act
-        $requiredTransfer->toArray();
+        // @phpstan-ignore expr.resultUnused
+        $requiredTransfer->iAmRequired;
     }
 
     /**

--- a/tests/integration/Transfer/data/config/definition/book-advanced.transfer.yml
+++ b/tests/integration/Transfer/data/config/definition/book-advanced.transfer.yml
@@ -1,0 +1,6 @@
+# $schema: ./../../../../../../schema/definition.schema.json
+Book:
+  data:
+    type: "Picamator\\Tests\\Integration\\TransferObject\\Transfer\\Advanced\\BookData"
+  bookmarks:
+    collectionType: "Picamator\\Tests\\Integration\\TransferObject\\Transfer\\Advanced\\BookmarkData"

--- a/tests/integration/TransferGenerator/Generated/Success/AddressBookTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressBookTransfer.php
@@ -26,77 +26,71 @@ final class AddressBookTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 6;
 
     protected const array META_DATA = [
-        self::ADDRESSES => self::ADDRESSES_DATA_NAME,
-        self::CATEGORIES => self::CATEGORIES_DATA_NAME,
-        self::LABEL => self::LABEL_DATA_NAME,
-        self::LABEL_ALIAS => self::LABEL_ALIAS_DATA_NAME,
-        self::NAME => self::NAME_DATA_NAME,
-        self::UUID => self::UUID_DATA_NAME,
+        self::ADDRESSES_INDEX => self::ADDRESSES,
+        self::CATEGORIES_INDEX => self::CATEGORIES,
+        self::LABEL_INDEX => self::LABEL,
+        self::LABEL_ALIAS_INDEX => self::LABEL_ALIAS,
+        self::NAME_INDEX => self::NAME,
+        self::UUID_INDEX => self::UUID,
     ];
 
     // addresses
     #[CollectionPropertyTypeAttribute(AddressTransfer::class)]
     public const string ADDRESSES = 'addresses';
-    protected const string ADDRESSES_DATA_NAME = 'ADDRESSES';
-    protected const int ADDRESSES_DATA_INDEX = 0;
+    protected const int ADDRESSES_INDEX = 0;
 
     /** @var \ArrayObject<int,AddressTransfer> */
     public ArrayObject $addresses {
-        get => $this->getData(self::ADDRESSES_DATA_INDEX);
-        set => $this->setData(self::ADDRESSES_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESSES_INDEX);
+        set => $this->setData(self::ADDRESSES_INDEX, $value);
     }
 
     // categories
     #[ArrayPropertyTypeAttribute]
     public const string CATEGORIES = 'categories';
-    protected const string CATEGORIES_DATA_NAME = 'CATEGORIES';
-    protected const int CATEGORIES_DATA_INDEX = 1;
+    protected const int CATEGORIES_INDEX = 1;
 
     /** @var array<int|string,mixed> */
     public array $categories {
-        get => $this->getData(self::CATEGORIES_DATA_INDEX);
-        set => $this->setData(self::CATEGORIES_DATA_INDEX, $value);
+        get => $this->getData(self::CATEGORIES_INDEX);
+        set => $this->setData(self::CATEGORIES_INDEX, $value);
     }
 
     // label
     #[EnumPropertyTypeAttribute(AddressLabelEnum::class)]
     public const string LABEL = 'label';
-    protected const string LABEL_DATA_NAME = 'LABEL';
-    protected const int LABEL_DATA_INDEX = 2;
+    protected const int LABEL_INDEX = 2;
 
     public ?AddressLabelEnum $label {
-        get => $this->getData(self::LABEL_DATA_INDEX);
-        set => $this->setData(self::LABEL_DATA_INDEX, $value);
+        get => $this->getData(self::LABEL_INDEX);
+        set => $this->setData(self::LABEL_INDEX, $value);
     }
 
     // labelAlias
     #[EnumPropertyTypeAttribute(AliasAddressLabelEnum::class)]
     public const string LABEL_ALIAS = 'labelAlias';
-    protected const string LABEL_ALIAS_DATA_NAME = 'LABEL_ALIAS';
-    protected const int LABEL_ALIAS_DATA_INDEX = 3;
+    protected const int LABEL_ALIAS_INDEX = 3;
 
     public ?AliasAddressLabelEnum $labelAlias {
-        get => $this->getData(self::LABEL_ALIAS_DATA_INDEX);
-        set => $this->setData(self::LABEL_ALIAS_DATA_INDEX, $value);
+        get => $this->getData(self::LABEL_ALIAS_INDEX);
+        set => $this->setData(self::LABEL_ALIAS_INDEX, $value);
     }
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 4;
+    protected const int NAME_INDEX = 4;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 
     // uuid
     public const string UUID = 'uuid';
-    protected const string UUID_DATA_NAME = 'UUID';
-    protected const int UUID_DATA_INDEX = 5;
+    protected const int UUID_INDEX = 5;
 
     public ?string $uuid {
-        get => $this->getData(self::UUID_DATA_INDEX);
-        set => $this->setData(self::UUID_DATA_INDEX, $value);
+        get => $this->getData(self::UUID_INDEX);
+        set => $this->setData(self::UUID_INDEX, $value);
     }
 }

--- a/tests/integration/TransferGenerator/Generated/Success/AddressStatisticsTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressStatisticsTransfer.php
@@ -22,84 +22,77 @@ final class AddressStatisticsTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 7;
 
     protected const array META_DATA = [
-        self::ADDRESS_BOOK_UUID => self::ADDRESS_BOOK_UUID_DATA_NAME,
-        self::ADDRESS_UUID => self::ADDRESS_UUID_DATA_NAME,
-        self::IS_ACTIVE => self::IS_ACTIVE_DATA_NAME,
-        self::IS_BLOCKED => self::IS_BLOCKED_DATA_NAME,
-        self::ORDER_AVERAGE => self::ORDER_AVERAGE_DATA_NAME,
-        self::ORDER_COUNT => self::ORDER_COUNT_DATA_NAME,
-        self::ORDER_REFERENCES => self::ORDER_REFERENCES_DATA_NAME,
+        self::ADDRESS_BOOK_UUID_INDEX => self::ADDRESS_BOOK_UUID,
+        self::ADDRESS_UUID_INDEX => self::ADDRESS_UUID,
+        self::IS_ACTIVE_INDEX => self::IS_ACTIVE,
+        self::IS_BLOCKED_INDEX => self::IS_BLOCKED,
+        self::ORDER_AVERAGE_INDEX => self::ORDER_AVERAGE,
+        self::ORDER_COUNT_INDEX => self::ORDER_COUNT,
+        self::ORDER_REFERENCES_INDEX => self::ORDER_REFERENCES,
     ];
 
     // addressBookUuid
     public const string ADDRESS_BOOK_UUID = 'addressBookUuid';
-    protected const string ADDRESS_BOOK_UUID_DATA_NAME = 'ADDRESS_BOOK_UUID';
-    protected const int ADDRESS_BOOK_UUID_DATA_INDEX = 0;
+    protected const int ADDRESS_BOOK_UUID_INDEX = 0;
 
     public ?string $addressBookUuid {
-        get => $this->getData(self::ADDRESS_BOOK_UUID_DATA_INDEX);
-        set => $this->setData(self::ADDRESS_BOOK_UUID_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS_BOOK_UUID_INDEX);
+        set => $this->setData(self::ADDRESS_BOOK_UUID_INDEX, $value);
     }
 
     // addressUuid
     public const string ADDRESS_UUID = 'addressUuid';
-    protected const string ADDRESS_UUID_DATA_NAME = 'ADDRESS_UUID';
-    protected const int ADDRESS_UUID_DATA_INDEX = 1;
+    protected const int ADDRESS_UUID_INDEX = 1;
 
     public ?string $addressUuid {
-        get => $this->getData(self::ADDRESS_UUID_DATA_INDEX);
-        set => $this->setData(self::ADDRESS_UUID_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS_UUID_INDEX);
+        set => $this->setData(self::ADDRESS_UUID_INDEX, $value);
     }
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const string IS_ACTIVE_DATA_NAME = 'IS_ACTIVE';
-    protected const int IS_ACTIVE_DATA_INDEX = 2;
+    protected const int IS_ACTIVE_INDEX = 2;
 
     public ?true $isActive {
-        get => $this->getData(self::IS_ACTIVE_DATA_INDEX);
-        set => $this->setData(self::IS_ACTIVE_DATA_INDEX, $value);
+        get => $this->getData(self::IS_ACTIVE_INDEX);
+        set => $this->setData(self::IS_ACTIVE_INDEX, $value);
     }
 
     // isBlocked
     public const string IS_BLOCKED = 'isBlocked';
-    protected const string IS_BLOCKED_DATA_NAME = 'IS_BLOCKED';
-    protected const int IS_BLOCKED_DATA_INDEX = 3;
+    protected const int IS_BLOCKED_INDEX = 3;
 
     public ?false $isBlocked {
-        get => $this->getData(self::IS_BLOCKED_DATA_INDEX);
-        set => $this->setData(self::IS_BLOCKED_DATA_INDEX, $value);
+        get => $this->getData(self::IS_BLOCKED_INDEX);
+        set => $this->setData(self::IS_BLOCKED_INDEX, $value);
     }
 
     // orderAverage
     public const string ORDER_AVERAGE = 'orderAverage';
-    protected const string ORDER_AVERAGE_DATA_NAME = 'ORDER_AVERAGE';
-    protected const int ORDER_AVERAGE_DATA_INDEX = 4;
+    protected const int ORDER_AVERAGE_INDEX = 4;
 
     public ?float $orderAverage {
-        get => $this->getData(self::ORDER_AVERAGE_DATA_INDEX);
-        set => $this->setData(self::ORDER_AVERAGE_DATA_INDEX, $value);
+        get => $this->getData(self::ORDER_AVERAGE_INDEX);
+        set => $this->setData(self::ORDER_AVERAGE_INDEX, $value);
     }
 
     // orderCount
     public const string ORDER_COUNT = 'orderCount';
-    protected const string ORDER_COUNT_DATA_NAME = 'ORDER_COUNT';
-    protected const int ORDER_COUNT_DATA_INDEX = 5;
+    protected const int ORDER_COUNT_INDEX = 5;
 
     public ?int $orderCount {
-        get => $this->getData(self::ORDER_COUNT_DATA_INDEX);
-        set => $this->setData(self::ORDER_COUNT_DATA_INDEX, $value);
+        get => $this->getData(self::ORDER_COUNT_INDEX);
+        set => $this->setData(self::ORDER_COUNT_INDEX, $value);
     }
 
     // orderReferences
     #[ArrayObjectPropertyTypeAttribute]
     public const string ORDER_REFERENCES = 'orderReferences';
-    protected const string ORDER_REFERENCES_DATA_NAME = 'ORDER_REFERENCES';
-    protected const int ORDER_REFERENCES_DATA_INDEX = 6;
+    protected const int ORDER_REFERENCES_INDEX = 6;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $orderReferences {
-        get => $this->getData(self::ORDER_REFERENCES_DATA_INDEX);
-        set => $this->setData(self::ORDER_REFERENCES_DATA_INDEX, $value);
+        get => $this->getData(self::ORDER_REFERENCES_INDEX);
+        set => $this->setData(self::ORDER_REFERENCES_INDEX, $value);
     }
 }

--- a/tests/integration/TransferGenerator/Generated/Success/AddressTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressTransfer.php
@@ -22,117 +22,107 @@ final class AddressTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 10;
 
     protected const array META_DATA = [
-        self::ADDRESS1 => self::ADDRESS1_DATA_NAME,
-        self::ADDRESS2 => self::ADDRESS2_DATA_NAME,
-        self::ADDRESS3 => self::ADDRESS3_DATA_NAME,
-        self::COUNTRY => self::COUNTRY_DATA_NAME,
-        self::FIRST_NAME => self::FIRST_NAME_DATA_NAME,
-        self::IS_ACTIVE => self::IS_ACTIVE_DATA_NAME,
-        self::LAST_NAME => self::LAST_NAME_DATA_NAME,
-        self::PHONE => self::PHONE_DATA_NAME,
-        self::UUID => self::UUID_DATA_NAME,
-        self::ZIP_CODE => self::ZIP_CODE_DATA_NAME,
+        self::ADDRESS1_INDEX => self::ADDRESS1,
+        self::ADDRESS2_INDEX => self::ADDRESS2,
+        self::ADDRESS3_INDEX => self::ADDRESS3,
+        self::COUNTRY_INDEX => self::COUNTRY,
+        self::FIRST_NAME_INDEX => self::FIRST_NAME,
+        self::IS_ACTIVE_INDEX => self::IS_ACTIVE,
+        self::LAST_NAME_INDEX => self::LAST_NAME,
+        self::PHONE_INDEX => self::PHONE,
+        self::UUID_INDEX => self::UUID,
+        self::ZIP_CODE_INDEX => self::ZIP_CODE,
     ];
 
     // address1
     public const string ADDRESS1 = 'address1';
-    protected const string ADDRESS1_DATA_NAME = 'ADDRESS1';
-    protected const int ADDRESS1_DATA_INDEX = 0;
+    protected const int ADDRESS1_INDEX = 0;
 
     public ?string $address1 {
-        get => $this->getData(self::ADDRESS1_DATA_INDEX);
-        set => $this->setData(self::ADDRESS1_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS1_INDEX);
+        set => $this->setData(self::ADDRESS1_INDEX, $value);
     }
 
     // address2
     public const string ADDRESS2 = 'address2';
-    protected const string ADDRESS2_DATA_NAME = 'ADDRESS2';
-    protected const int ADDRESS2_DATA_INDEX = 1;
+    protected const int ADDRESS2_INDEX = 1;
 
     public ?string $address2 {
-        get => $this->getData(self::ADDRESS2_DATA_INDEX);
-        set => $this->setData(self::ADDRESS2_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS2_INDEX);
+        set => $this->setData(self::ADDRESS2_INDEX, $value);
     }
 
     // address3
     public const string ADDRESS3 = 'address3';
-    protected const string ADDRESS3_DATA_NAME = 'ADDRESS3';
-    protected const int ADDRESS3_DATA_INDEX = 2;
+    protected const int ADDRESS3_INDEX = 2;
 
     public ?string $address3 {
-        get => $this->getData(self::ADDRESS3_DATA_INDEX);
-        set => $this->setData(self::ADDRESS3_DATA_INDEX, $value);
+        get => $this->getData(self::ADDRESS3_INDEX);
+        set => $this->setData(self::ADDRESS3_INDEX, $value);
     }
 
     // country
     #[CollectionPropertyTypeAttribute(CountryTransfer::class)]
     public const string COUNTRY = 'country';
-    protected const string COUNTRY_DATA_NAME = 'COUNTRY';
-    protected const int COUNTRY_DATA_INDEX = 3;
+    protected const int COUNTRY_INDEX = 3;
 
     /** @var \ArrayObject<int,CountryTransfer> */
     public ArrayObject $country {
-        get => $this->getData(self::COUNTRY_DATA_INDEX);
-        set => $this->setData(self::COUNTRY_DATA_INDEX, $value);
+        get => $this->getData(self::COUNTRY_INDEX);
+        set => $this->setData(self::COUNTRY_INDEX, $value);
     }
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const string FIRST_NAME_DATA_NAME = 'FIRST_NAME';
-    protected const int FIRST_NAME_DATA_INDEX = 4;
+    protected const int FIRST_NAME_INDEX = 4;
 
     public ?string $firstName {
-        get => $this->getData(self::FIRST_NAME_DATA_INDEX);
-        set => $this->setData(self::FIRST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::FIRST_NAME_INDEX);
+        set => $this->setData(self::FIRST_NAME_INDEX, $value);
     }
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const string IS_ACTIVE_DATA_NAME = 'IS_ACTIVE';
-    protected const int IS_ACTIVE_DATA_INDEX = 5;
+    protected const int IS_ACTIVE_INDEX = 5;
 
     public ?bool $isActive {
-        get => $this->getData(self::IS_ACTIVE_DATA_INDEX);
-        set => $this->setData(self::IS_ACTIVE_DATA_INDEX, $value);
+        get => $this->getData(self::IS_ACTIVE_INDEX);
+        set => $this->setData(self::IS_ACTIVE_INDEX, $value);
     }
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const string LAST_NAME_DATA_NAME = 'LAST_NAME';
-    protected const int LAST_NAME_DATA_INDEX = 6;
+    protected const int LAST_NAME_INDEX = 6;
 
     public ?string $lastName {
-        get => $this->getData(self::LAST_NAME_DATA_INDEX);
-        set => $this->setData(self::LAST_NAME_DATA_INDEX, $value);
+        get => $this->getData(self::LAST_NAME_INDEX);
+        set => $this->setData(self::LAST_NAME_INDEX, $value);
     }
 
     // phone
     public const string PHONE = 'phone';
-    protected const string PHONE_DATA_NAME = 'PHONE';
-    protected const int PHONE_DATA_INDEX = 7;
+    protected const int PHONE_INDEX = 7;
 
     public ?string $phone {
-        get => $this->getData(self::PHONE_DATA_INDEX);
-        set => $this->setData(self::PHONE_DATA_INDEX, $value);
+        get => $this->getData(self::PHONE_INDEX);
+        set => $this->setData(self::PHONE_INDEX, $value);
     }
 
     // uuid
     public const string UUID = 'uuid';
-    protected const string UUID_DATA_NAME = 'UUID';
-    protected const int UUID_DATA_INDEX = 8;
+    protected const int UUID_INDEX = 8;
 
     public ?string $uuid {
-        get => $this->getData(self::UUID_DATA_INDEX);
-        set => $this->setData(self::UUID_DATA_INDEX, $value);
+        get => $this->getData(self::UUID_INDEX);
+        set => $this->setData(self::UUID_INDEX, $value);
     }
 
     // zipCode
     public const string ZIP_CODE = 'zipCode';
-    protected const string ZIP_CODE_DATA_NAME = 'ZIP_CODE';
-    protected const int ZIP_CODE_DATA_INDEX = 9;
+    protected const int ZIP_CODE_INDEX = 9;
 
     public ?string $zipCode {
-        get => $this->getData(self::ZIP_CODE_DATA_INDEX);
-        set => $this->setData(self::ZIP_CODE_DATA_INDEX, $value);
+        get => $this->getData(self::ZIP_CODE_INDEX);
+        set => $this->setData(self::ZIP_CODE_INDEX, $value);
     }
 }

--- a/tests/integration/TransferGenerator/Generated/Success/CountryTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/CountryTransfer.php
@@ -20,27 +20,25 @@ final class CountryTransfer extends AbstractTransfer
     protected const int META_DATA_SIZE = 2;
 
     protected const array META_DATA = [
-        self::ISO2_CODE => self::ISO2_CODE_DATA_NAME,
-        self::NAME => self::NAME_DATA_NAME,
+        self::ISO2_CODE_INDEX => self::ISO2_CODE,
+        self::NAME_INDEX => self::NAME,
     ];
 
     // iso2Code
     public const string ISO2_CODE = 'iso2Code';
-    protected const string ISO2_CODE_DATA_NAME = 'ISO2_CODE';
-    protected const int ISO2_CODE_DATA_INDEX = 0;
+    protected const int ISO2_CODE_INDEX = 0;
 
     public ?string $iso2Code {
-        get => $this->getData(self::ISO2_CODE_DATA_INDEX);
-        set => $this->setData(self::ISO2_CODE_DATA_INDEX, $value);
+        get => $this->getData(self::ISO2_CODE_INDEX);
+        set => $this->setData(self::ISO2_CODE_INDEX, $value);
     }
 
     // name
     public const string NAME = 'name';
-    protected const string NAME_DATA_NAME = 'NAME';
-    protected const int NAME_DATA_INDEX = 1;
+    protected const int NAME_INDEX = 1;
 
     public ?string $name {
-        get => $this->getData(self::NAME_DATA_INDEX);
-        set => $this->setData(self::NAME_DATA_INDEX, $value);
+        get => $this->getData(self::NAME_INDEX);
+        set => $this->setData(self::NAME_INDEX, $value);
     }
 }

--- a/tests/integration/TransferGenerator/TransferGeneratorFacadeErrorTest.php
+++ b/tests/integration/TransferGenerator/TransferGeneratorFacadeErrorTest.php
@@ -153,6 +153,11 @@ class TransferGeneratorFacadeErrorTest extends TestCase
             'configCaseName' => 'invalid-type-namespace-with-alias',
             'expectedMessage' => 'Invalid namespace',
         ];
+
+        yield 'invalid date time type' => [
+            'configCaseName' => 'invalid-date-time-type',
+            'expectedMessage' => 'does not implement DateTimeInterface',
+        ];
     }
 
     public function testGenerateTransfersOrFailTransferGeneratorShouldFailOnError(): void

--- a/tests/integration/TransferGenerator/data/config/error/invalid-date-time-type/definition/address-statistics.transfer.yml
+++ b/tests/integration/TransferGenerator/data/config/error/invalid-date-time-type/definition/address-statistics.transfer.yml
@@ -1,0 +1,3 @@
+AddressStatistics:
+  addressBookUuid:
+    dateTimeType: "DateTimeImmutableInvalid"

--- a/tests/integration/TransferGenerator/data/config/error/invalid-date-time-type/generator.config.yml
+++ b/tests/integration/TransferGenerator/data/config/error/invalid-date-time-type/generator.config.yml
@@ -1,0 +1,4 @@
+generator:
+  transferNamespace: "Picamator\\Tests\\Integration\\TransferObject\\TransferGenerator\\Generated\\Error"
+  transferPath: "${PROJECT_ROOT}/tests/integration/TransferGenerator/Generated/Error"
+  definitionPath: "${PROJECT_ROOT}/tests/integration/TransferGenerator/data/config/error/invalid-date-time-type/definition"

--- a/tests/unit/DefinitionGenerator/Builder/DefinitionContentBuilderTest.php
+++ b/tests/unit/DefinitionGenerator/Builder/DefinitionContentBuilderTest.php
@@ -31,8 +31,21 @@ class DefinitionContentBuilderTest extends TestCase
     public function testUnsupportedTypeShouldThrowException(): void
     {
         // Arrange
-        $propertyName = 'file.txt';
+        $propertyName = 'file';
         $propertyValue = $this->getTempFileStream();
+
+        // Expect
+        $this->expectException(DefinitionGeneratorException::class);
+
+        // Act
+        $this->builder->createBuilderContent($propertyName, $propertyValue);
+    }
+
+    public function testInvalidPropertyNameShouldThrowException(): void
+    {
+        // Arrange
+        $propertyName = 'file.txt';
+        $propertyValue = 'something';
 
         // Expect
         $this->expectException(DefinitionGeneratorException::class);

--- a/tests/unit/Shared/Filesystem/FileAppenderTest.php
+++ b/tests/unit/Shared/Filesystem/FileAppenderTest.php
@@ -112,6 +112,19 @@ class FileAppenderTest extends TestCase
         $this->fileAppenderMock->closeFile(self::FILE_NAME);
     }
 
+    public function testFileIsNotExistInTheCacheShouldSkipCloseFile(): void
+    {
+        // Arrange
+        $fileName = 'some-name.txt';
+
+        // Expect
+        $this->fileAppenderMock->expects($this->never())
+            ->method('fclose');
+
+        // Act
+        $this->fileAppenderMock->closeFile($fileName);
+    }
+
     public function testFailedCloseFile(): void
     {
         // Arrange

--- a/tests/unit/TransferGenerator/Definition/Validator/Content/Property/NumberTypePropertyValidatorTest.php
+++ b/tests/unit/TransferGenerator/Definition/Validator/Content/Property/NumberTypePropertyValidatorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Picamator\Tests\Unit\TransferObject\TransferGenerator\Definition\Validator\Content\Property;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Picamator\TransferObject\Generated\DefinitionEmbeddedTypeTransfer;
+use Picamator\TransferObject\Generated\DefinitionNamespaceTransfer;
+use Picamator\TransferObject\Generated\DefinitionPropertyTransfer;
+use Picamator\TransferObject\TransferGenerator\Definition\Validator\Content\Property\NumberTypePropertyValidator;
+use Picamator\TransferObject\TransferGenerator\Definition\Validator\Content\Property\PropertyValidatorInterface;
+
+#[Group('transfer-generator')]
+class NumberTypePropertyValidatorTest extends TestCase
+{
+    private PropertyValidatorInterface&MockObject $validatorMock;
+
+    protected function setUp(): void
+    {
+        $this->validatorMock = $this->getMockBuilder(NumberTypePropertyValidator::class)
+            ->onlyMethods(['isBcMathLoaded'])
+            ->getMock();
+    }
+
+    public function testBcMathWasNotLoadedShouldReturnError(): void
+    {
+        // Arrange
+        $propertyTransfer = new DefinitionPropertyTransfer();
+
+        // Expect
+        $this->validatorMock->expects($this->once())
+            ->method('isBcMathLoaded')
+            ->willReturn(false);
+
+        // Act
+        $actual = $this->validatorMock->validate($propertyTransfer);
+
+        // Assert
+        $this->assertFalse($actual->isValid);
+        $this->assertStringContainsString('PHP extension BCMath was not loaded', $actual->errorMessage);
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testInvalidBcMathTypeShouldReturnError(): void
+    {
+        // Arrange
+        $namespaceTransfer = new DefinitionNamespaceTransfer();
+        $namespaceTransfer->withoutAlias = 'SomeClassName';
+
+        $embeddedTypeTransfer = new DefinitionEmbeddedTypeTransfer();
+        $embeddedTypeTransfer->namespace = $namespaceTransfer;
+        $embeddedTypeTransfer->name = 'SomeClassName';
+
+        $propertyTransfer = new DefinitionPropertyTransfer();
+        $propertyTransfer->propertyName = 'someName';
+        $propertyTransfer->numberType = $embeddedTypeTransfer;
+
+        // Expect
+        $this->validatorMock->expects($this->once())
+            ->method('isBcMathLoaded')
+            ->willReturn(true);
+
+        // Act
+        $actual = $this->validatorMock->validate($propertyTransfer);
+
+        // Assert
+        $this->assertFalse($actual->isValid);
+        $this->assertStringContainsString('is not a BcMath\Number', $actual->errorMessage);
+    }
+}


### PR DESCRIPTION
Release 3.0.0
=========

Breaking Changes
--------------------

1. Removed deprecated Transfer Object Interface method  `Picamator\TransferObject\Transfer\TransferInterface::toFilterArray()`. Use trait `Picamator\TransferObject\Transfer\FilterArrayTrait` instead.
2. Removed Transfer Object meta constant `*_DATA_NAME`
3. Added new reserved property `_reflectionObjectReference`
4. Requred `symfony ^7.3` components instead of `^7.0`


**Action Required:**

1. Check if the definition file uses reserved property `_reflectionObjectReference`. Rename the propoerty if it is used.
2. Regenerate Transfer Objects

Improvements
----------------

**Transfer Object:**

1. Refactored `Picamator\TransferObject\Transfer\AbstractTransfer`  methods `initData`, `getIterator`,  `fromArray`, and `toArray`
3. Used [WeakReference](https://www.php.net/manual/en/class.weakreference.php) to cache objects reflection on `ConstantAttributeTrait` and `TransferAdapterTrait`

**Tests:**

1. Improved code coverage
2. Added PHPStan and CodeSniffer rules

Type of Change
--------------

Please delete options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

Checklist
---------

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [x] I agree to follow this project's [Code of Conduct](https://github.com/picamator/transfer-object/blob/main/CODE_OF_CONDUCT.md).
