### PR TITLE
Release 3.0.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.3.10",
+            "version": "12.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0d401d0df2e3c1703be425ecdc2d04f5c095938d"
+                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0d401d0df2e3c1703be425ecdc2d04f5c095938d",
-                "reference": "0d401d0df2e3c1703be425ecdc2d04f5c095938d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a62f2b394e042884e4997ddc8b8db1ce56a0009",
+                "reference": "6a62f2b394e042884e4997ddc8b8db1ce56a0009",
                 "shasum": ""
             },
             "require": {
@@ -1938,7 +1938,7 @@
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.0.0",
+                "sebastian/cli-parser": "^4.1.0",
                 "sebastian/comparator": "^7.1.3",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.3",
@@ -1987,7 +1987,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.11"
             },
             "funding": [
                 {
@@ -2011,20 +2011,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:35:19+00:00"
+            "time": "2025-09-14T06:21:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "8fd93be538992d556aaa45c74570129448a42084"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/8fd93be538992d556aaa45c74570129448a42084",
-                "reference": "8fd93be538992d556aaa45c74570129448a42084",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
@@ -2036,7 +2036,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.1-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2060,7 +2060,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
@@ -2080,7 +2080,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-13T14:16:18+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",

--- a/src/Transfer/AbstractTransfer.php
+++ b/src/Transfer/AbstractTransfer.php
@@ -101,7 +101,7 @@ abstract class AbstractTransfer implements TransferInterface
 
         foreach (static::META_DATA as $index => $propertyName) {
             $data[$propertyName] = isset($attributes[$propertyName])
-                ? $attributes[$propertyName]->toArray($this->{$propertyName})
+                ? $attributes[$propertyName]->toArray($this->_data[$index])
                 : $this->_data[$index];
         }
 
@@ -118,6 +118,7 @@ abstract class AbstractTransfer implements TransferInterface
         }
 
         $attributes = $this->getTypeAttributes();
+
         foreach ($data as $propertyName => $value) {
             $this->{$propertyName} = isset($attributes[$propertyName])
                 ? $attributes[$propertyName]->fromArray($value)

--- a/src/TransferGenerator/Definition/Enum/BuildInTypeEnum.php
+++ b/src/TransferGenerator/Definition/Enum/BuildInTypeEnum.php
@@ -15,27 +15,26 @@ enum BuildInTypeEnum: string
     case ARRAY = 'array';
     case ARRAY_OBJECT = 'ArrayObject';
 
+    private const array IS_ALLOWED = [
+        self::BOOL,
+        self::TRUE,
+        self::FALSE,
+        self::INT,
+        self::FLOAT,
+        self::STRING,
+        self::ARRAY,
+        self::ARRAY_OBJECT,
+    ];
+
     case ITERABLE = 'iterable';
     case NULL = 'null';
     case OBJECT = 'object';
     case MIXED = 'mixed';
     case CALLABLE = 'callable';
 
-    private const array NOT_ALLOWED = [
-        self::ITERABLE,
-        self::NULL,
-        self::OBJECT,
-        self::MIXED,
-        self::CALLABLE,
-    ];
-
     public static function getTrueFalse(bool $value): self
     {
-        if ($value === true) {
-            return self::TRUE;
-        }
-
-        return self::FALSE;
+        return $value === true ? self::TRUE : self::FALSE;
     }
 
     public function isArray(): bool
@@ -50,6 +49,6 @@ enum BuildInTypeEnum: string
 
     public function isAllowed(): bool
     {
-        return !in_array($this, self::NOT_ALLOWED, true);
+        return in_array($this, self::IS_ALLOWED, true);
     }
 }


### PR DESCRIPTION
Release 3.0.1
========

1. Fixed mixed property access on `AbstractTransfer::toArray()` where on the same loop requesting data from `_data` and property
2. Refactored `BuildInTypeEnum::isAllowed()` to use whitelist instead of blacklist approach
3. Updated composer dependencies 

Type of Change
--------------

- [x] Code style change and minor refactoring

Checklist
---------

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [x] I agree to follow this project's [Code of Conduct](https://github.com/picamator/transfer-object/blob/main/CODE_OF_CONDUCT.md).
