### PR TITLE
Release 3.0.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1470,16 +1470,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.28",
+            "version": "2.1.29",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "578fa296a166605d97b94091f724f1257185d278"
+                "url": "https://github.com/phpstan/phpstan-phar-composer-source.git",
+                "reference": "git"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
-                "reference": "578fa296a166605d97b94091f724f1257185d278",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "reference": "d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
                 "shasum": ""
             },
             "require": {
@@ -1524,25 +1524,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-19T08:58:49+00:00"
+            "time": "2025-09-25T06:58:18+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.6",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094"
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/f9f77efa9de31992a832ff77ea52eb42d675b094",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0.4"
+                "phpstan/phpstan": "^2.1.29"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -1570,22 +1570,22 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
             },
-            "time": "2025-07-21T12:19:29+00:00"
+            "time": "2025-09-26T11:19:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.3.8",
+            "version": "12.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "99e692c6a84708211f7536ba322bbbaef57ac7fc"
+                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/99e692c6a84708211f7536ba322bbbaef57ac7fc",
-                "reference": "99e692c6a84708211f7536ba322bbbaef57ac7fc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
+                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
                 "shasum": ""
             },
             "require": {
@@ -1612,7 +1612,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.3.x-dev"
+                    "dev-main": "12.4.x-dev"
                 }
             },
             "autoload": {
@@ -1641,7 +1641,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.3.8"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.4.0"
             },
             "funding": [
                 {
@@ -1661,7 +1661,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-17T11:31:43+00:00"
+            "time": "2025-09-24T13:44:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.3.13",
+            "version": "12.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "44f15312c4968fa8102e491fc6f3746410819c16"
+                "reference": "13e9b2bea9327b094176147250d2c10319a10f5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/44f15312c4968fa8102e491fc6f3746410819c16",
-                "reference": "44f15312c4968fa8102e491fc6f3746410819c16",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/13e9b2bea9327b094176147250d2c10319a10f5b",
+                "reference": "13e9b2bea9327b094176147250d2c10319a10f5b",
                 "shasum": ""
             },
             "require": {
@@ -1942,7 +1942,7 @@
                 "sebastian/comparator": "^7.1.3",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.3",
-                "sebastian/exporter": "^7.0.1",
+                "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/type": "^6.0.3",
@@ -1987,7 +1987,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.3.14"
             },
             "funding": [
                 {
@@ -2011,7 +2011,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-23T06:25:02+00:00"
+            "time": "2025-09-24T06:34:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2377,16 +2377,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.1",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "b759164a8e02263784b662889cc6cbb686077af6"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b759164a8e02263784b662889cc6cbb686077af6",
-                "reference": "b759164a8e02263784b662889cc6cbb686077af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
@@ -2443,7 +2443,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
@@ -2463,7 +2463,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-22T05:39:29+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/examples/Generated/AdvancedTransferGenerator/AdvancedCustomerTransfer.php
+++ b/examples/Generated/AdvancedTransferGenerator/AdvancedCustomerTransfer.php
@@ -33,7 +33,7 @@ final class AdvancedCustomerTransfer extends AbstractTransfer
     // address
     #[PropertyTypeAttribute(AddressData::class)]
     public const string ADDRESS = 'address';
-    protected const int ADDRESS_INDEX = 0;
+    private const int ADDRESS_INDEX = 0;
 
     public TransferInterface&AddressData $address {
         get => $this->getData(self::ADDRESS_INDEX);
@@ -43,7 +43,7 @@ final class AdvancedCustomerTransfer extends AbstractTransfer
     // credentials
     #[PropertyTypeAttribute(CredentialsData::class)]
     public const string CREDENTIALS = 'credentials';
-    protected const int CREDENTIALS_INDEX = 1;
+    private const int CREDENTIALS_INDEX = 1;
 
     public TransferInterface&CredentialsData $credentials {
         get => $this->getData(self::CREDENTIALS_INDEX);
@@ -53,7 +53,7 @@ final class AdvancedCustomerTransfer extends AbstractTransfer
     // customer
     #[PropertyTypeAttribute(CustomerTransfer::class)]
     public const string CUSTOMER = 'customer';
-    protected const int CUSTOMER_INDEX = 2;
+    private const int CUSTOMER_INDEX = 2;
 
     public TransferInterface&CustomerTransfer $customer {
         get => $this->getData(self::CUSTOMER_INDEX);

--- a/examples/Generated/DefinitionGenerator/AvailabilitiesTransfer.php
+++ b/examples/Generated/DefinitionGenerator/AvailabilitiesTransfer.php
@@ -26,7 +26,7 @@ final class AvailabilitiesTransfer extends AbstractTransfer
 
     // buffer
     public const string BUFFER = 'buffer';
-    protected const int BUFFER_INDEX = 0;
+    private const int BUFFER_INDEX = 0;
 
     public ?int $buffer {
         get => $this->getData(self::BUFFER_INDEX);
@@ -35,7 +35,7 @@ final class AvailabilitiesTransfer extends AbstractTransfer
 
     // total
     public const string TOTAL = 'total';
-    protected const int TOTAL_INDEX = 1;
+    private const int TOTAL_INDEX = 1;
 
     public ?int $total {
         get => $this->getData(self::TOTAL_INDEX);

--- a/examples/Generated/DefinitionGenerator/BoxTransfer.php
+++ b/examples/Generated/DefinitionGenerator/BoxTransfer.php
@@ -26,7 +26,7 @@ final class BoxTransfer extends AbstractTransfer
 
     // items
     public const string ITEMS = 'items';
-    protected const int ITEMS_INDEX = 0;
+    private const int ITEMS_INDEX = 0;
 
     public ?int $items {
         get => $this->getData(self::ITEMS_INDEX);
@@ -35,7 +35,7 @@ final class BoxTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 1;
+    private const int TYPE_INDEX = 1;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/examples/Generated/DefinitionGenerator/DeliveryOptionsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/DeliveryOptionsTransfer.php
@@ -25,7 +25,7 @@ final class DeliveryOptionsTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 0;
+    private const int NAME_INDEX = 0;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);

--- a/examples/Generated/DefinitionGenerator/DetailsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/DetailsTransfer.php
@@ -26,7 +26,7 @@ final class DetailsTransfer extends AbstractTransfer
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const int DESCRIPTION_INDEX = 0;
+    private const int DESCRIPTION_INDEX = 0;
 
     public ?string $description {
         get => $this->getData(self::DESCRIPTION_INDEX);
@@ -35,7 +35,7 @@ final class DetailsTransfer extends AbstractTransfer
 
     // isRegional
     public const string IS_REGIONAL = 'isRegional';
-    protected const int IS_REGIONAL_INDEX = 1;
+    private const int IS_REGIONAL_INDEX = 1;
 
     public ?bool $isRegional {
         get => $this->getData(self::IS_REGIONAL_INDEX);

--- a/examples/Generated/DefinitionGenerator/LabelsTransfer.php
+++ b/examples/Generated/DefinitionGenerator/LabelsTransfer.php
@@ -25,7 +25,7 @@ final class LabelsTransfer extends AbstractTransfer
 
     // sale
     public const string SALE = 'sale';
-    protected const int SALE_INDEX = 0;
+    private const int SALE_INDEX = 0;
 
     public ?string $sale {
         get => $this->getData(self::SALE_INDEX);

--- a/examples/Generated/DefinitionGenerator/MeasurementUnitTransfer.php
+++ b/examples/Generated/DefinitionGenerator/MeasurementUnitTransfer.php
@@ -28,7 +28,7 @@ final class MeasurementUnitTransfer extends AbstractTransfer
     // box
     #[PropertyTypeAttribute(BoxTransfer::class)]
     public const string BOX = 'box';
-    protected const int BOX_INDEX = 0;
+    private const int BOX_INDEX = 0;
 
     public ?BoxTransfer $box {
         get => $this->getData(self::BOX_INDEX);
@@ -38,7 +38,7 @@ final class MeasurementUnitTransfer extends AbstractTransfer
     // palette
     #[PropertyTypeAttribute(PaletteTransfer::class)]
     public const string PALETTE = 'palette';
-    protected const int PALETTE_INDEX = 1;
+    private const int PALETTE_INDEX = 1;
 
     public ?PaletteTransfer $palette {
         get => $this->getData(self::PALETTE_INDEX);

--- a/examples/Generated/DefinitionGenerator/PaletteTransfer.php
+++ b/examples/Generated/DefinitionGenerator/PaletteTransfer.php
@@ -26,7 +26,7 @@ final class PaletteTransfer extends AbstractTransfer
 
     // items
     public const string ITEMS = 'items';
-    protected const int ITEMS_INDEX = 0;
+    private const int ITEMS_INDEX = 0;
 
     public ?int $items {
         get => $this->getData(self::ITEMS_INDEX);
@@ -35,7 +35,7 @@ final class PaletteTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 1;
+    private const int TYPE_INDEX = 1;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/examples/Generated/DefinitionGenerator/ProductTransfer.php
+++ b/examples/Generated/DefinitionGenerator/ProductTransfer.php
@@ -41,7 +41,7 @@ final class ProductTransfer extends AbstractTransfer
     // availabilities
     #[CollectionPropertyTypeAttribute(AvailabilitiesTransfer::class)]
     public const string AVAILABILITIES = 'availabilities';
-    protected const int AVAILABILITIES_INDEX = 0;
+    private const int AVAILABILITIES_INDEX = 0;
 
     /** @var \ArrayObject<int,AvailabilitiesTransfer> */
     public ArrayObject $availabilities {
@@ -51,7 +51,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // currency
     public const string CURRENCY = 'currency';
-    protected const int CURRENCY_INDEX = 1;
+    private const int CURRENCY_INDEX = 1;
 
     public ?string $currency {
         get => $this->getData(self::CURRENCY_INDEX);
@@ -61,7 +61,7 @@ final class ProductTransfer extends AbstractTransfer
     // deliveryOptions
     #[CollectionPropertyTypeAttribute(DeliveryOptionsTransfer::class)]
     public const string DELIVERY_OPTIONS = 'deliveryOptions';
-    protected const int DELIVERY_OPTIONS_INDEX = 2;
+    private const int DELIVERY_OPTIONS_INDEX = 2;
 
     /** @var \ArrayObject<int,DeliveryOptionsTransfer> */
     public ArrayObject $deliveryOptions {
@@ -72,7 +72,7 @@ final class ProductTransfer extends AbstractTransfer
     // details
     #[PropertyTypeAttribute(DetailsTransfer::class)]
     public const string DETAILS = 'details';
-    protected const int DETAILS_INDEX = 3;
+    private const int DETAILS_INDEX = 3;
 
     public ?DetailsTransfer $details {
         get => $this->getData(self::DETAILS_INDEX);
@@ -81,7 +81,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // isDiscounted
     public const string IS_DISCOUNTED = 'isDiscounted';
-    protected const int IS_DISCOUNTED_INDEX = 4;
+    private const int IS_DISCOUNTED_INDEX = 4;
 
     public ?bool $isDiscounted {
         get => $this->getData(self::IS_DISCOUNTED_INDEX);
@@ -91,7 +91,7 @@ final class ProductTransfer extends AbstractTransfer
     // labels
     #[PropertyTypeAttribute(LabelsTransfer::class)]
     public const string LABELS = 'labels';
-    protected const int LABELS_INDEX = 5;
+    private const int LABELS_INDEX = 5;
 
     public ?LabelsTransfer $labels {
         get => $this->getData(self::LABELS_INDEX);
@@ -101,7 +101,7 @@ final class ProductTransfer extends AbstractTransfer
     // measurementUnit
     #[PropertyTypeAttribute(MeasurementUnitTransfer::class)]
     public const string MEASUREMENT_UNIT = 'measurementUnit';
-    protected const int MEASUREMENT_UNIT_INDEX = 6;
+    private const int MEASUREMENT_UNIT_INDEX = 6;
 
     public ?MeasurementUnitTransfer $measurementUnit {
         get => $this->getData(self::MEASUREMENT_UNIT_INDEX);
@@ -110,7 +110,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 7;
+    private const int NAME_INDEX = 7;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);
@@ -119,7 +119,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // price
     public const string PRICE = 'price';
-    protected const int PRICE_INDEX = 8;
+    private const int PRICE_INDEX = 8;
 
     public ?float $price {
         get => $this->getData(self::PRICE_INDEX);
@@ -128,7 +128,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // sku
     public const string SKU = 'sku';
-    protected const int SKU_INDEX = 9;
+    private const int SKU_INDEX = 9;
 
     public ?string $sku {
         get => $this->getData(self::SKU_INDEX);
@@ -137,7 +137,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // stock
     public const string STOCK = 'stock';
-    protected const int STOCK_INDEX = 10;
+    private const int STOCK_INDEX = 10;
 
     public ?int $stock {
         get => $this->getData(self::STOCK_INDEX);
@@ -147,7 +147,7 @@ final class ProductTransfer extends AbstractTransfer
     // stores
     #[ArrayPropertyTypeAttribute]
     public const string STORES = 'stores';
-    protected const int STORES_INDEX = 11;
+    private const int STORES_INDEX = 11;
 
     /** @var array<int|string,mixed> */
     public array $stores {

--- a/examples/Generated/TransferGenerator/AgentTransfer.php
+++ b/examples/Generated/TransferGenerator/AgentTransfer.php
@@ -30,7 +30,7 @@ final class AgentTransfer extends AbstractTransfer
     // customer
     #[PropertyTypeAttribute(CustomerTransfer::class)]
     public const string CUSTOMER = 'customer';
-    protected const int CUSTOMER_INDEX = 0;
+    private const int CUSTOMER_INDEX = 0;
 
     public ?CustomerTransfer $customer {
         get => $this->getData(self::CUSTOMER_INDEX);
@@ -40,7 +40,7 @@ final class AgentTransfer extends AbstractTransfer
     // merchants
     #[CollectionPropertyTypeAttribute(MerchantTransfer::class)]
     public const string MERCHANTS = 'merchants';
-    protected const int MERCHANTS_INDEX = 1;
+    private const int MERCHANTS_INDEX = 1;
 
     /** @var \ArrayObject<int,MerchantTransfer> */
     public ArrayObject $merchants {

--- a/examples/Generated/TransferGenerator/CredentialsTransfer.php
+++ b/examples/Generated/TransferGenerator/CredentialsTransfer.php
@@ -32,7 +32,7 @@ final class CredentialsTransfer extends AbstractTransfer
     // createdAt
     #[DateTimePropertyTypeAttribute(DateTimeImmutable::class)]
     public const string CREATED_AT = 'createdAt';
-    protected const int CREATED_AT_INDEX = 0;
+    private const int CREATED_AT_INDEX = 0;
 
     public protected(set) DateTimeImmutable $createdAt {
         get => $this->getData(self::CREATED_AT_INDEX);
@@ -41,7 +41,7 @@ final class CredentialsTransfer extends AbstractTransfer
 
     // login
     public const string LOGIN = 'login';
-    protected const int LOGIN_INDEX = 1;
+    private const int LOGIN_INDEX = 1;
 
     public protected(set) string $login {
         get => $this->getData(self::LOGIN_INDEX);
@@ -50,7 +50,7 @@ final class CredentialsTransfer extends AbstractTransfer
 
     // token
     public const string TOKEN = 'token';
-    protected const int TOKEN_INDEX = 2;
+    private const int TOKEN_INDEX = 2;
 
     public protected(set) string $token {
         get => $this->getData(self::TOKEN_INDEX);
@@ -60,7 +60,7 @@ final class CredentialsTransfer extends AbstractTransfer
     // updatedAt
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string UPDATED_AT = 'updatedAt';
-    protected const int UPDATED_AT_INDEX = 3;
+    private const int UPDATED_AT_INDEX = 3;
 
     public DateTime $updatedAt {
         get => $this->getData(self::UPDATED_AT_INDEX);

--- a/examples/Generated/TransferGenerator/CustomerTransfer.php
+++ b/examples/Generated/TransferGenerator/CustomerTransfer.php
@@ -26,7 +26,7 @@ final class CustomerTransfer extends AbstractTransfer
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const int FIRST_NAME_INDEX = 0;
+    private const int FIRST_NAME_INDEX = 0;
 
     public ?string $firstName {
         get => $this->getData(self::FIRST_NAME_INDEX);
@@ -35,7 +35,7 @@ final class CustomerTransfer extends AbstractTransfer
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const int LAST_NAME_INDEX = 1;
+    private const int LAST_NAME_INDEX = 1;
 
     public ?string $lastName {
         get => $this->getData(self::LAST_NAME_INDEX);

--- a/examples/Generated/TransferGenerator/MerchantTransfer.php
+++ b/examples/Generated/TransferGenerator/MerchantTransfer.php
@@ -30,7 +30,7 @@ final class MerchantTransfer extends AbstractTransfer
     // country
     #[EnumPropertyTypeAttribute(CountryEnum::class)]
     public const string COUNTRY = 'country';
-    protected const int COUNTRY_INDEX = 0;
+    private const int COUNTRY_INDEX = 0;
 
     public CountryEnum $country {
         get => $this->getData(self::COUNTRY_INDEX);
@@ -39,7 +39,7 @@ final class MerchantTransfer extends AbstractTransfer
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const int IS_ACTIVE_INDEX = 1;
+    private const int IS_ACTIVE_INDEX = 1;
 
     public bool $isActive {
         get => $this->getData(self::IS_ACTIVE_INDEX);
@@ -48,7 +48,7 @@ final class MerchantTransfer extends AbstractTransfer
 
     // merchantReference
     public const string MERCHANT_REFERENCE = 'merchantReference';
-    protected const int MERCHANT_REFERENCE_INDEX = 2;
+    private const int MERCHANT_REFERENCE_INDEX = 2;
 
     public string $merchantReference {
         get => $this->getData(self::MERCHANT_REFERENCE_INDEX);

--- a/src/Generated/ConfigContentTransfer.php
+++ b/src/Generated/ConfigContentTransfer.php
@@ -28,7 +28,7 @@ final class ConfigContentTransfer extends AbstractTransfer
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const int DEFINITION_PATH_INDEX = 0;
+    private const int DEFINITION_PATH_INDEX = 0;
 
     public string $definitionPath {
         get => $this->getData(self::DEFINITION_PATH_INDEX);
@@ -37,7 +37,7 @@ final class ConfigContentTransfer extends AbstractTransfer
 
     // relativeDefinitionPath
     public const string RELATIVE_DEFINITION_PATH = 'relativeDefinitionPath';
-    protected const int RELATIVE_DEFINITION_PATH_INDEX = 1;
+    private const int RELATIVE_DEFINITION_PATH_INDEX = 1;
 
     public string $relativeDefinitionPath {
         get => $this->getData(self::RELATIVE_DEFINITION_PATH_INDEX);
@@ -46,7 +46,7 @@ final class ConfigContentTransfer extends AbstractTransfer
 
     // transferNamespace
     public const string TRANSFER_NAMESPACE = 'transferNamespace';
-    protected const int TRANSFER_NAMESPACE_INDEX = 2;
+    private const int TRANSFER_NAMESPACE_INDEX = 2;
 
     public string $transferNamespace {
         get => $this->getData(self::TRANSFER_NAMESPACE_INDEX);
@@ -55,7 +55,7 @@ final class ConfigContentTransfer extends AbstractTransfer
 
     // transferPath
     public const string TRANSFER_PATH = 'transferPath';
-    protected const int TRANSFER_PATH_INDEX = 3;
+    private const int TRANSFER_PATH_INDEX = 3;
 
     public string $transferPath {
         get => $this->getData(self::TRANSFER_PATH_INDEX);

--- a/src/Generated/ConfigTransfer.php
+++ b/src/Generated/ConfigTransfer.php
@@ -28,7 +28,7 @@ final class ConfigTransfer extends AbstractTransfer
     // content
     #[PropertyTypeAttribute(ConfigContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 0;
+    private const int CONTENT_INDEX = 0;
 
     public ConfigContentTransfer $content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -38,7 +38,7 @@ final class ConfigTransfer extends AbstractTransfer
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const int VALIDATOR_INDEX = 1;
+    private const int VALIDATOR_INDEX = 1;
 
     public ValidatorTransfer $validator {
         get => $this->getData(self::VALIDATOR_INDEX);

--- a/src/Generated/DefinitionBuilderTransfer.php
+++ b/src/Generated/DefinitionBuilderTransfer.php
@@ -30,7 +30,7 @@ final class DefinitionBuilderTransfer extends AbstractTransfer
     // definitionContent
     #[PropertyTypeAttribute(DefinitionContentTransfer::class)]
     public const string DEFINITION_CONTENT = 'definitionContent';
-    protected const int DEFINITION_CONTENT_INDEX = 0;
+    private const int DEFINITION_CONTENT_INDEX = 0;
 
     public DefinitionContentTransfer $definitionContent {
         get => $this->getData(self::DEFINITION_CONTENT_INDEX);
@@ -40,7 +40,7 @@ final class DefinitionBuilderTransfer extends AbstractTransfer
     // generatorContents
     #[CollectionPropertyTypeAttribute(DefinitionGeneratorContentTransfer::class)]
     public const string GENERATOR_CONTENTS = 'generatorContents';
-    protected const int GENERATOR_CONTENTS_INDEX = 1;
+    private const int GENERATOR_CONTENTS_INDEX = 1;
 
     /** @var \ArrayObject<int,DefinitionGeneratorContentTransfer> */
     public ArrayObject $generatorContents {

--- a/src/Generated/DefinitionContentTransfer.php
+++ b/src/Generated/DefinitionContentTransfer.php
@@ -28,7 +28,7 @@ final class DefinitionContentTransfer extends AbstractTransfer
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const int CLASS_NAME_INDEX = 0;
+    private const int CLASS_NAME_INDEX = 0;
 
     public string $className {
         get => $this->getData(self::CLASS_NAME_INDEX);
@@ -38,7 +38,7 @@ final class DefinitionContentTransfer extends AbstractTransfer
     // properties
     #[CollectionPropertyTypeAttribute(DefinitionPropertyTransfer::class)]
     public const string PROPERTIES = 'properties';
-    protected const int PROPERTIES_INDEX = 1;
+    private const int PROPERTIES_INDEX = 1;
 
     /** @var \ArrayObject<int,DefinitionPropertyTransfer> */
     public ArrayObject $properties {

--- a/src/Generated/DefinitionEmbeddedTypeTransfer.php
+++ b/src/Generated/DefinitionEmbeddedTypeTransfer.php
@@ -27,7 +27,7 @@ final class DefinitionEmbeddedTypeTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 0;
+    private const int NAME_INDEX = 0;
 
     public string $name {
         get => $this->getData(self::NAME_INDEX);
@@ -37,7 +37,7 @@ final class DefinitionEmbeddedTypeTransfer extends AbstractTransfer
     // namespace
     #[PropertyTypeAttribute(DefinitionNamespaceTransfer::class)]
     public const string NAMESPACE = 'namespace';
-    protected const int NAMESPACE_INDEX = 1;
+    private const int NAMESPACE_INDEX = 1;
 
     public ?DefinitionNamespaceTransfer $namespace {
         get => $this->getData(self::NAMESPACE_INDEX);

--- a/src/Generated/DefinitionFilesystemTransfer.php
+++ b/src/Generated/DefinitionFilesystemTransfer.php
@@ -27,7 +27,7 @@ final class DefinitionFilesystemTransfer extends AbstractTransfer
 
     // content
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 0;
+    private const int CONTENT_INDEX = 0;
 
     public string $content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -36,7 +36,7 @@ final class DefinitionFilesystemTransfer extends AbstractTransfer
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const int DEFINITION_PATH_INDEX = 1;
+    private const int DEFINITION_PATH_INDEX = 1;
 
     public string $definitionPath {
         get => $this->getData(self::DEFINITION_PATH_INDEX);
@@ -45,7 +45,7 @@ final class DefinitionFilesystemTransfer extends AbstractTransfer
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const int FILE_NAME_INDEX = 2;
+    private const int FILE_NAME_INDEX = 2;
 
     public string $fileName {
         get => $this->getData(self::FILE_NAME_INDEX);

--- a/src/Generated/DefinitionGeneratorContentTransfer.php
+++ b/src/Generated/DefinitionGeneratorContentTransfer.php
@@ -27,7 +27,7 @@ final class DefinitionGeneratorContentTransfer extends AbstractTransfer
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const int CLASS_NAME_INDEX = 0;
+    private const int CLASS_NAME_INDEX = 0;
 
     public string $className {
         get => $this->getData(self::CLASS_NAME_INDEX);
@@ -37,7 +37,7 @@ final class DefinitionGeneratorContentTransfer extends AbstractTransfer
     // content
     #[ArrayPropertyTypeAttribute]
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     /** @var array<int|string,mixed> */
     public array $content {

--- a/src/Generated/DefinitionGeneratorTransfer.php
+++ b/src/Generated/DefinitionGeneratorTransfer.php
@@ -28,7 +28,7 @@ final class DefinitionGeneratorTransfer extends AbstractTransfer
     // content
     #[PropertyTypeAttribute(DefinitionGeneratorContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 0;
+    private const int CONTENT_INDEX = 0;
 
     public DefinitionGeneratorContentTransfer $content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -37,7 +37,7 @@ final class DefinitionGeneratorTransfer extends AbstractTransfer
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const int DEFINITION_PATH_INDEX = 1;
+    private const int DEFINITION_PATH_INDEX = 1;
 
     public string $definitionPath {
         get => $this->getData(self::DEFINITION_PATH_INDEX);

--- a/src/Generated/DefinitionNamespaceTransfer.php
+++ b/src/Generated/DefinitionNamespaceTransfer.php
@@ -28,7 +28,7 @@ final class DefinitionNamespaceTransfer extends AbstractTransfer
 
     // alias
     public const string ALIAS = 'alias';
-    protected const int ALIAS_INDEX = 0;
+    private const int ALIAS_INDEX = 0;
 
     public ?string $alias {
         get => $this->getData(self::ALIAS_INDEX);
@@ -37,7 +37,7 @@ final class DefinitionNamespaceTransfer extends AbstractTransfer
 
     // baseName
     public const string BASE_NAME = 'baseName';
-    protected const int BASE_NAME_INDEX = 1;
+    private const int BASE_NAME_INDEX = 1;
 
     public string $baseName {
         get => $this->getData(self::BASE_NAME_INDEX);
@@ -46,7 +46,7 @@ final class DefinitionNamespaceTransfer extends AbstractTransfer
 
     // fullName
     public const string FULL_NAME = 'fullName';
-    protected const int FULL_NAME_INDEX = 2;
+    private const int FULL_NAME_INDEX = 2;
 
     public string $fullName {
         get => $this->getData(self::FULL_NAME_INDEX);
@@ -55,7 +55,7 @@ final class DefinitionNamespaceTransfer extends AbstractTransfer
 
     // withoutAlias
     public const string WITHOUT_ALIAS = 'withoutAlias';
-    protected const int WITHOUT_ALIAS_INDEX = 3;
+    private const int WITHOUT_ALIAS_INDEX = 3;
 
     public string $withoutAlias {
         get => $this->getData(self::WITHOUT_ALIAS_INDEX);

--- a/src/Generated/DefinitionPropertyTransfer.php
+++ b/src/Generated/DefinitionPropertyTransfer.php
@@ -37,7 +37,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // buildInType
     #[EnumPropertyTypeAttribute(BuildInTypeEnum::class)]
     public const string BUILD_IN_TYPE = 'buildInType';
-    protected const int BUILD_IN_TYPE_INDEX = 0;
+    private const int BUILD_IN_TYPE_INDEX = 0;
 
     public ?BuildInTypeEnum $buildInType {
         get => $this->getData(self::BUILD_IN_TYPE_INDEX);
@@ -47,7 +47,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // collectionType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string COLLECTION_TYPE = 'collectionType';
-    protected const int COLLECTION_TYPE_INDEX = 1;
+    private const int COLLECTION_TYPE_INDEX = 1;
 
     public ?DefinitionEmbeddedTypeTransfer $collectionType {
         get => $this->getData(self::COLLECTION_TYPE_INDEX);
@@ -57,7 +57,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // dateTimeType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string DATE_TIME_TYPE = 'dateTimeType';
-    protected const int DATE_TIME_TYPE_INDEX = 2;
+    private const int DATE_TIME_TYPE_INDEX = 2;
 
     public ?DefinitionEmbeddedTypeTransfer $dateTimeType {
         get => $this->getData(self::DATE_TIME_TYPE_INDEX);
@@ -67,7 +67,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // enumType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string ENUM_TYPE = 'enumType';
-    protected const int ENUM_TYPE_INDEX = 3;
+    private const int ENUM_TYPE_INDEX = 3;
 
     public ?DefinitionEmbeddedTypeTransfer $enumType {
         get => $this->getData(self::ENUM_TYPE_INDEX);
@@ -76,7 +76,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
 
     // isNullable
     public const string IS_NULLABLE = 'isNullable';
-    protected const int IS_NULLABLE_INDEX = 4;
+    private const int IS_NULLABLE_INDEX = 4;
 
     public bool $isNullable {
         get => $this->getData(self::IS_NULLABLE_INDEX);
@@ -85,7 +85,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
 
     // isProtected
     public const string IS_PROTECTED = 'isProtected';
-    protected const int IS_PROTECTED_INDEX = 5;
+    private const int IS_PROTECTED_INDEX = 5;
 
     public bool $isProtected {
         get => $this->getData(self::IS_PROTECTED_INDEX);
@@ -95,7 +95,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // numberType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string NUMBER_TYPE = 'numberType';
-    protected const int NUMBER_TYPE_INDEX = 6;
+    private const int NUMBER_TYPE_INDEX = 6;
 
     public ?DefinitionEmbeddedTypeTransfer $numberType {
         get => $this->getData(self::NUMBER_TYPE_INDEX);
@@ -104,7 +104,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
 
     // propertyName
     public const string PROPERTY_NAME = 'propertyName';
-    protected const int PROPERTY_NAME_INDEX = 7;
+    private const int PROPERTY_NAME_INDEX = 7;
 
     public string $propertyName {
         get => $this->getData(self::PROPERTY_NAME_INDEX);
@@ -114,7 +114,7 @@ final class DefinitionPropertyTransfer extends AbstractTransfer
     // transferType
     #[PropertyTypeAttribute(DefinitionEmbeddedTypeTransfer::class)]
     public const string TRANSFER_TYPE = 'transferType';
-    protected const int TRANSFER_TYPE_INDEX = 8;
+    private const int TRANSFER_TYPE_INDEX = 8;
 
     public ?DefinitionEmbeddedTypeTransfer $transferType {
         get => $this->getData(self::TRANSFER_TYPE_INDEX);

--- a/src/Generated/DefinitionTransfer.php
+++ b/src/Generated/DefinitionTransfer.php
@@ -29,7 +29,7 @@ final class DefinitionTransfer extends AbstractTransfer
     // content
     #[PropertyTypeAttribute(DefinitionContentTransfer::class)]
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 0;
+    private const int CONTENT_INDEX = 0;
 
     public DefinitionContentTransfer $content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -38,7 +38,7 @@ final class DefinitionTransfer extends AbstractTransfer
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const int FILE_NAME_INDEX = 1;
+    private const int FILE_NAME_INDEX = 1;
 
     public string $fileName {
         get => $this->getData(self::FILE_NAME_INDEX);
@@ -48,7 +48,7 @@ final class DefinitionTransfer extends AbstractTransfer
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const int VALIDATOR_INDEX = 2;
+    private const int VALIDATOR_INDEX = 2;
 
     public ValidatorTransfer $validator {
         get => $this->getData(self::VALIDATOR_INDEX);

--- a/src/Generated/FileReaderProgressTransfer.php
+++ b/src/Generated/FileReaderProgressTransfer.php
@@ -27,7 +27,7 @@ final class FileReaderProgressTransfer extends AbstractTransfer
 
     // content
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 0;
+    private const int CONTENT_INDEX = 0;
 
     public string $content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -36,7 +36,7 @@ final class FileReaderProgressTransfer extends AbstractTransfer
 
     // progressBytes
     public const string PROGRESS_BYTES = 'progressBytes';
-    protected const int PROGRESS_BYTES_INDEX = 1;
+    private const int PROGRESS_BYTES_INDEX = 1;
 
     public int $progressBytes {
         get => $this->getData(self::PROGRESS_BYTES_INDEX);
@@ -45,7 +45,7 @@ final class FileReaderProgressTransfer extends AbstractTransfer
 
     // totalBytes
     public const string TOTAL_BYTES = 'totalBytes';
-    protected const int TOTAL_BYTES_INDEX = 2;
+    private const int TOTAL_BYTES_INDEX = 2;
 
     public int $totalBytes {
         get => $this->getData(self::TOTAL_BYTES_INDEX);

--- a/src/Generated/TemplateTransfer.php
+++ b/src/Generated/TemplateTransfer.php
@@ -37,7 +37,7 @@ final class TemplateTransfer extends AbstractTransfer
     // attributes
     #[ArrayObjectPropertyTypeAttribute]
     public const string ATTRIBUTES = 'attributes';
-    protected const int ATTRIBUTES_INDEX = 0;
+    private const int ATTRIBUTES_INDEX = 0;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $attributes {
@@ -47,7 +47,7 @@ final class TemplateTransfer extends AbstractTransfer
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const int CLASS_NAME_INDEX = 1;
+    private const int CLASS_NAME_INDEX = 1;
 
     public string $className {
         get => $this->getData(self::CLASS_NAME_INDEX);
@@ -56,7 +56,7 @@ final class TemplateTransfer extends AbstractTransfer
 
     // classNamespace
     public const string CLASS_NAMESPACE = 'classNamespace';
-    protected const int CLASS_NAMESPACE_INDEX = 2;
+    private const int CLASS_NAMESPACE_INDEX = 2;
 
     public string $classNamespace {
         get => $this->getData(self::CLASS_NAMESPACE_INDEX);
@@ -65,7 +65,7 @@ final class TemplateTransfer extends AbstractTransfer
 
     // definitionPath
     public const string DEFINITION_PATH = 'definitionPath';
-    protected const int DEFINITION_PATH_INDEX = 3;
+    private const int DEFINITION_PATH_INDEX = 3;
 
     public string $definitionPath {
         get => $this->getData(self::DEFINITION_PATH_INDEX);
@@ -75,7 +75,7 @@ final class TemplateTransfer extends AbstractTransfer
     // dockBlocks
     #[ArrayObjectPropertyTypeAttribute]
     public const string DOCK_BLOCKS = 'dockBlocks';
-    protected const int DOCK_BLOCKS_INDEX = 4;
+    private const int DOCK_BLOCKS_INDEX = 4;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $dockBlocks {
@@ -86,7 +86,7 @@ final class TemplateTransfer extends AbstractTransfer
     // imports
     #[ArrayObjectPropertyTypeAttribute]
     public const string IMPORTS = 'imports';
-    protected const int IMPORTS_INDEX = 5;
+    private const int IMPORTS_INDEX = 5;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $imports {
@@ -97,7 +97,7 @@ final class TemplateTransfer extends AbstractTransfer
     // metaConstants
     #[ArrayObjectPropertyTypeAttribute]
     public const string META_CONSTANTS = 'metaConstants';
-    protected const int META_CONSTANTS_INDEX = 6;
+    private const int META_CONSTANTS_INDEX = 6;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $metaConstants {
@@ -108,7 +108,7 @@ final class TemplateTransfer extends AbstractTransfer
     // nullables
     #[ArrayObjectPropertyTypeAttribute]
     public const string NULLABLES = 'nullables';
-    protected const int NULLABLES_INDEX = 7;
+    private const int NULLABLES_INDEX = 7;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $nullables {
@@ -119,7 +119,7 @@ final class TemplateTransfer extends AbstractTransfer
     // properties
     #[ArrayObjectPropertyTypeAttribute]
     public const string PROPERTIES = 'properties';
-    protected const int PROPERTIES_INDEX = 8;
+    private const int PROPERTIES_INDEX = 8;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $properties {
@@ -130,7 +130,7 @@ final class TemplateTransfer extends AbstractTransfer
     // protects
     #[ArrayObjectPropertyTypeAttribute]
     public const string PROTECTS = 'protects';
-    protected const int PROTECTS_INDEX = 9;
+    private const int PROTECTS_INDEX = 9;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $protects {

--- a/src/Generated/TransferGeneratorBulkTransfer.php
+++ b/src/Generated/TransferGeneratorBulkTransfer.php
@@ -28,7 +28,7 @@ final class TransferGeneratorBulkTransfer extends AbstractTransfer
     // progress
     #[PropertyTypeAttribute(FileReaderProgressTransfer::class)]
     public const string PROGRESS = 'progress';
-    protected const int PROGRESS_INDEX = 0;
+    private const int PROGRESS_INDEX = 0;
 
     public FileReaderProgressTransfer $progress {
         get => $this->getData(self::PROGRESS_INDEX);
@@ -38,7 +38,7 @@ final class TransferGeneratorBulkTransfer extends AbstractTransfer
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const int VALIDATOR_INDEX = 1;
+    private const int VALIDATOR_INDEX = 1;
 
     public ValidatorTransfer $validator {
         get => $this->getData(self::VALIDATOR_INDEX);

--- a/src/Generated/TransferGeneratorContentTransfer.php
+++ b/src/Generated/TransferGeneratorContentTransfer.php
@@ -26,7 +26,7 @@ final class TransferGeneratorContentTransfer extends AbstractTransfer
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const int CLASS_NAME_INDEX = 0;
+    private const int CLASS_NAME_INDEX = 0;
 
     public protected(set) string $className {
         get => $this->getData(self::CLASS_NAME_INDEX);
@@ -35,7 +35,7 @@ final class TransferGeneratorContentTransfer extends AbstractTransfer
 
     // content
     public const string CONTENT = 'content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     public protected(set) string $content {
         get => $this->getData(self::CONTENT_INDEX);

--- a/src/Generated/TransferGeneratorTransfer.php
+++ b/src/Generated/TransferGeneratorTransfer.php
@@ -28,7 +28,7 @@ final class TransferGeneratorTransfer extends AbstractTransfer
 
     // className
     public const string CLASS_NAME = 'className';
-    protected const int CLASS_NAME_INDEX = 0;
+    private const int CLASS_NAME_INDEX = 0;
 
     public ?string $className {
         get => $this->getData(self::CLASS_NAME_INDEX);
@@ -37,7 +37,7 @@ final class TransferGeneratorTransfer extends AbstractTransfer
 
     // fileName
     public const string FILE_NAME = 'fileName';
-    protected const int FILE_NAME_INDEX = 1;
+    private const int FILE_NAME_INDEX = 1;
 
     public ?string $fileName {
         get => $this->getData(self::FILE_NAME_INDEX);
@@ -47,7 +47,7 @@ final class TransferGeneratorTransfer extends AbstractTransfer
     // validator
     #[PropertyTypeAttribute(ValidatorTransfer::class)]
     public const string VALIDATOR = 'validator';
-    protected const int VALIDATOR_INDEX = 2;
+    private const int VALIDATOR_INDEX = 2;
 
     public ValidatorTransfer $validator {
         get => $this->getData(self::VALIDATOR_INDEX);

--- a/src/Generated/ValidatorMessageTransfer.php
+++ b/src/Generated/ValidatorMessageTransfer.php
@@ -26,7 +26,7 @@ final class ValidatorMessageTransfer extends AbstractTransfer
 
     // errorMessage
     public const string ERROR_MESSAGE = 'errorMessage';
-    protected const int ERROR_MESSAGE_INDEX = 0;
+    private const int ERROR_MESSAGE_INDEX = 0;
 
     public protected(set) string $errorMessage {
         get => $this->getData(self::ERROR_MESSAGE_INDEX);
@@ -35,7 +35,7 @@ final class ValidatorMessageTransfer extends AbstractTransfer
 
     // isValid
     public const string IS_VALID = 'isValid';
-    protected const int IS_VALID_INDEX = 1;
+    private const int IS_VALID_INDEX = 1;
 
     public protected(set) bool $isValid {
         get => $this->getData(self::IS_VALID_INDEX);

--- a/src/Generated/ValidatorTransfer.php
+++ b/src/Generated/ValidatorTransfer.php
@@ -29,7 +29,7 @@ final class ValidatorTransfer extends AbstractTransfer
     // errorMessages
     #[CollectionPropertyTypeAttribute(ValidatorMessageTransfer::class)]
     public const string ERROR_MESSAGES = 'errorMessages';
-    protected const int ERROR_MESSAGES_INDEX = 0;
+    private const int ERROR_MESSAGES_INDEX = 0;
 
     /** @var \ArrayObject<int,ValidatorMessageTransfer> */
     public ArrayObject $errorMessages {
@@ -39,7 +39,7 @@ final class ValidatorTransfer extends AbstractTransfer
 
     // isValid
     public const string IS_VALID = 'isValid';
-    protected const int IS_VALID_INDEX = 1;
+    private const int IS_VALID_INDEX = 1;
 
     public bool $isValid {
         get => $this->getData(self::IS_VALID_INDEX);

--- a/src/Transfer/Attribute/CollectionPropertyTypeAttribute.php
+++ b/src/Transfer/Attribute/CollectionPropertyTypeAttribute.php
@@ -52,7 +52,7 @@ final readonly class CollectionPropertyTypeAttribute implements InitialPropertyT
     public function toArray(mixed $data): array
     {
         return array_map(
-            fn(TransferInterface $transfer): array => $transfer->toArray(),
+            fn (TransferInterface $transfer): array => $transfer->toArray(),
             $data->getArrayCopy()
         );
     }

--- a/src/TransferGenerator/Config/Enum/ConfigKeyEnum.php
+++ b/src/TransferGenerator/Config/Enum/ConfigKeyEnum.php
@@ -13,24 +13,15 @@ enum ConfigKeyEnum: string
     case DEFINITION_PATH = ConfigContentTransfer::DEFINITION_PATH;
 
     /**
-     * @return array<string,string>
-     */
-    public static function getConfigKeys(): array
-    {
-        return array_column(self::cases(), column_key: 'name', index_key: 'value');
-    }
-
-    /**
      * @return array<string, string>
      */
     public static function getDefaultConfig(): array
     {
-        /** @var array<string> $configKeys */
-        $configKeys = array_column(self::cases(), column_key: 'value');
+        $defaultContent = [];
+        foreach (self::cases() as $keyEnum) {
+            $defaultContent[$keyEnum->value] = '';
+        }
 
-        /** @var array<string, string> $defaultValueContent */
-        $defaultValueContent = array_fill_keys($configKeys, '');
-
-        return $defaultValueContent;
+        return $defaultContent;
     }
 }

--- a/src/TransferGenerator/Config/Parser/Filter/ConfigFilterTrait.php
+++ b/src/TransferGenerator/Config/Parser/Filter/ConfigFilterTrait.php
@@ -15,16 +15,19 @@ trait ConfigFilterTrait
      */
     final protected function filterConfig(mixed $configData): array
     {
+        $defaultConfig = ConfigKeyEnum::getDefaultConfig();
         if (!is_array($configData)) {
-            return ConfigKeyEnum::getDefaultConfig();
+            return $defaultConfig;
         }
 
         $sectionData = $configData[self::CONFIG_SECTION_KEY] ?? [];
-        $sectionData = is_array($sectionData) ? $sectionData : [];
+        if ($sectionData === [] || !is_array($sectionData)) {
+            return $defaultConfig;
+        }
 
-        $filteredData = array_intersect_key($sectionData, ConfigKeyEnum::getConfigKeys());
-        $filteredData = array_filter($filteredData, fn(mixed $item): bool => is_string($item));
+        $filteredData = array_intersect_key($sectionData, $defaultConfig);
+        $filteredData = array_filter($filteredData, 'is_string');
 
-        return $filteredData + ConfigKeyEnum::getDefaultConfig();
+        return $filteredData + $defaultConfig;
     }
 }

--- a/src/TransferGenerator/Definition/Parser/Expander/ProtectedPropertyExpander.php
+++ b/src/TransferGenerator/Definition/Parser/Expander/ProtectedPropertyExpander.php
@@ -12,7 +12,7 @@ final class ProtectedPropertyExpander extends AbstractPropertyExpander
 
     protected function matchType(array $propertyType): string
     {
-        return (string)array_key_exists(self::PROTECTED_KEY, $propertyType) ? '1' : '0';
+        return array_key_exists(self::PROTECTED_KEY, $propertyType) ? '1' : '0';
     }
 
     protected function handleExpander(string $matchedType, DefinitionPropertyTransfer $propertyTransfer): void

--- a/src/TransferGenerator/Definition/Reader/DefinitionReader.php
+++ b/src/TransferGenerator/Definition/Reader/DefinitionReader.php
@@ -28,8 +28,9 @@ readonly class DefinitionReader implements DefinitionReaderInterface
 
     public function getDefinitions(): Generator
     {
+        $count = 0;
+
         try {
-            $count = 0;
             $definitionFiles = $this->finder->getDefinitionFiles();
             foreach ($definitionFiles as $fileName => $filePath) {
                 $contentGenerator = $this->getContentGenerator($fileName, $filePath);
@@ -79,7 +80,6 @@ readonly class DefinitionReader implements DefinitionReaderInterface
         $definitionTransfer = new DefinitionTransfer();
 
         $definitionTransfer->fileName = $fileName;
-
         $definitionTransfer->content = new DefinitionContentTransfer();
         $definitionTransfer->content->className = '';
         $definitionTransfer->validator = $this->createErrorValidatorTransfer($errorMessage);

--- a/src/TransferGenerator/Generator/Render/Expander/TemplateExpanderTrait.php
+++ b/src/TransferGenerator/Generator/Render/Expander/TemplateExpanderTrait.php
@@ -18,9 +18,9 @@ trait TemplateExpanderTrait
 
     final protected function expandImports(string|BackedEnum $className, TemplateTransfer $templateTransfer): void
     {
-        if ($className instanceof BackedEnum) {
-            $className = $className->value;
-        }
+        $className = is_string($className)
+            ? $className
+            : $className->value;
 
         $templateTransfer->imports[$className] ??= $className;
     }

--- a/src/TransferGenerator/Generator/Render/Template/Template.php
+++ b/src/TransferGenerator/Generator/Render/Template/Template.php
@@ -16,7 +16,7 @@ readonly class Template
     {
         $this->helper->setTemplateTransfer($templateTransfer);
 
-        $content = <<<TEMPLATE
+        return <<<TEMPLATE
 <?php
 
 declare(strict_types=1);
@@ -46,8 +46,6 @@ final class $templateTransfer->className extends AbstractTransfer
 }
 
 TEMPLATE;
-
-        return $content;
     }
 
     private function renderProperties(TemplateTransfer $templateTransfer): string
@@ -64,7 +62,7 @@ TEMPLATE;
 
     // $property{$this->helper->renderAttribute($property)}
     public const string $constant = '$property';
-    protected const int {$constant}_INDEX = $i;
+    private const int {$constant}_INDEX = $i;
 {$this->helper->renderDockBlock($property)}
     public{$this->helper->renderPropertyDeclaration($property)} \$$property {
         get => \$this->getData(self::{$constant}_INDEX);

--- a/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
+++ b/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
@@ -40,8 +40,13 @@ class TemplateHelper implements TemplateHelperInterface
     public function renderMetaData(): string
     {
         $metaData = [];
-        foreach (array_keys($this->templateTransfer->metaConstants->getArrayCopy()) as $value) {
-            $metaData[] = sprintf(self::META_DATA_TEMPLATE, $value);
+
+        $iterator = $this->templateTransfer->metaConstants->getIterator();
+        $iterator->rewind();
+
+        while ($iterator->valid()) {
+            $metaData[] = sprintf(self::META_DATA_TEMPLATE, $iterator->key());
+            $iterator->next();
         }
 
         return implode(PHP_EOL, $metaData);

--- a/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
+++ b/src/TransferGenerator/Generator/Render/Template/TemplateHelper.php
@@ -86,7 +86,10 @@ class TemplateHelper implements TemplateHelperInterface
     {
         /** @var string $propertyType */
         $propertyType = $this->templateTransfer->properties[$property];
-        if (!$this->templateTransfer->nullables[$property] || str_contains($propertyType, '&')) {
+        /** @var bool $isNullable */
+        $isNullable = $this->templateTransfer->nullables[$property];
+
+        if (!$isNullable || str_contains($propertyType, '&')) {
             return self::EMPTY_STRING;
         }
 

--- a/tests/integration/Command/Generated/Success/CommandTransfer.php
+++ b/tests/integration/Command/Generated/Success/CommandTransfer.php
@@ -25,7 +25,7 @@ final class CommandTransfer extends AbstractTransfer
 
     // run
     public const string RUN = 'run';
-    protected const int RUN_INDEX = 0;
+    private const int RUN_INDEX = 0;
 
     public ?true $run {
         get => $this->getData(self::RUN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/DestatisTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/DestatisTransfer.php
@@ -36,7 +36,7 @@ final class DestatisTransfer extends AbstractTransfer
 
     // Copyright
     public const string COPYRIGHT = 'Copyright';
-    protected const int COPYRIGHT_INDEX = 0;
+    private const int COPYRIGHT_INDEX = 0;
 
     public ?string $Copyright {
         get => $this->getData(self::COPYRIGHT_INDEX);
@@ -45,7 +45,7 @@ final class DestatisTransfer extends AbstractTransfer
 
     // Cubes
     public const string CUBES = 'Cubes';
-    protected const int CUBES_INDEX = 1;
+    private const int CUBES_INDEX = 1;
 
     public ?string $Cubes {
         get => $this->getData(self::CUBES_INDEX);
@@ -55,7 +55,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Ident
     #[PropertyTypeAttribute(IdentTransfer::class)]
     public const string IDENT = 'Ident';
-    protected const int IDENT_INDEX = 2;
+    private const int IDENT_INDEX = 2;
 
     public ?IdentTransfer $Ident {
         get => $this->getData(self::IDENT_INDEX);
@@ -65,7 +65,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Parameter
     #[PropertyTypeAttribute(ParameterTransfer::class)]
     public const string PARAMETER = 'Parameter';
-    protected const int PARAMETER_INDEX = 3;
+    private const int PARAMETER_INDEX = 3;
 
     public ?ParameterTransfer $Parameter {
         get => $this->getData(self::PARAMETER_INDEX);
@@ -75,7 +75,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Statistics
     #[CollectionPropertyTypeAttribute(StatisticsTransfer::class)]
     public const string STATISTICS = 'Statistics';
-    protected const int STATISTICS_INDEX = 4;
+    private const int STATISTICS_INDEX = 4;
 
     /** @var \ArrayObject<int,StatisticsTransfer> */
     public ArrayObject $Statistics {
@@ -86,7 +86,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Status
     #[PropertyTypeAttribute(StatusTransfer::class)]
     public const string STATUS = 'Status';
-    protected const int STATUS_INDEX = 5;
+    private const int STATUS_INDEX = 5;
 
     public ?StatusTransfer $Status {
         get => $this->getData(self::STATUS_INDEX);
@@ -96,7 +96,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Tables
     #[CollectionPropertyTypeAttribute(TablesTransfer::class)]
     public const string TABLES = 'Tables';
-    protected const int TABLES_INDEX = 6;
+    private const int TABLES_INDEX = 6;
 
     /** @var \ArrayObject<int,TablesTransfer> */
     public ArrayObject $Tables {
@@ -106,7 +106,7 @@ final class DestatisTransfer extends AbstractTransfer
 
     // Timeseries
     public const string TIMESERIES = 'Timeseries';
-    protected const int TIMESERIES_INDEX = 7;
+    private const int TIMESERIES_INDEX = 7;
 
     public ?string $Timeseries {
         get => $this->getData(self::TIMESERIES_INDEX);
@@ -116,7 +116,7 @@ final class DestatisTransfer extends AbstractTransfer
     // Variables
     #[CollectionPropertyTypeAttribute(VariablesTransfer::class)]
     public const string VARIABLES = 'Variables';
-    protected const int VARIABLES_INDEX = 8;
+    private const int VARIABLES_INDEX = 8;
 
     /** @var \ArrayObject<int,VariablesTransfer> */
     public ArrayObject $Variables {

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/IdentTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/IdentTransfer.php
@@ -26,7 +26,7 @@ final class IdentTransfer extends AbstractTransfer
 
     // Method
     public const string METHOD = 'Method';
-    protected const int METHOD_INDEX = 0;
+    private const int METHOD_INDEX = 0;
 
     public ?string $Method {
         get => $this->getData(self::METHOD_INDEX);
@@ -35,7 +35,7 @@ final class IdentTransfer extends AbstractTransfer
 
     // Service
     public const string SERVICE = 'Service';
-    protected const int SERVICE_INDEX = 1;
+    private const int SERVICE_INDEX = 1;
 
     public ?string $Service {
         get => $this->getData(self::SERVICE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/ParameterTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/ParameterTransfer.php
@@ -30,7 +30,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // category
     public const string CATEGORY = 'category';
-    protected const int CATEGORY_INDEX = 0;
+    private const int CATEGORY_INDEX = 0;
 
     public ?string $category {
         get => $this->getData(self::CATEGORY_INDEX);
@@ -39,7 +39,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // language
     public const string LANGUAGE = 'language';
-    protected const int LANGUAGE_INDEX = 1;
+    private const int LANGUAGE_INDEX = 1;
 
     public ?string $language {
         get => $this->getData(self::LANGUAGE_INDEX);
@@ -48,7 +48,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // pagelength
     public const string PAGELENGTH = 'pagelength';
-    protected const int PAGELENGTH_INDEX = 2;
+    private const int PAGELENGTH_INDEX = 2;
 
     public ?string $pagelength {
         get => $this->getData(self::PAGELENGTH_INDEX);
@@ -57,7 +57,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // password
     public const string PASSWORD = 'password';
-    protected const int PASSWORD_INDEX = 3;
+    private const int PASSWORD_INDEX = 3;
 
     public ?string $password {
         get => $this->getData(self::PASSWORD_INDEX);
@@ -66,7 +66,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // term
     public const string TERM = 'term';
-    protected const int TERM_INDEX = 4;
+    private const int TERM_INDEX = 4;
 
     public ?string $term {
         get => $this->getData(self::TERM_INDEX);
@@ -75,7 +75,7 @@ final class ParameterTransfer extends AbstractTransfer
 
     // username
     public const string USERNAME = 'username';
-    protected const int USERNAME_INDEX = 5;
+    private const int USERNAME_INDEX = 5;
 
     public ?string $username {
         get => $this->getData(self::USERNAME_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/StatisticsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/StatisticsTransfer.php
@@ -28,7 +28,7 @@ final class StatisticsTransfer extends AbstractTransfer
 
     // Code
     public const string CODE = 'Code';
-    protected const int CODE_INDEX = 0;
+    private const int CODE_INDEX = 0;
 
     public ?string $Code {
         get => $this->getData(self::CODE_INDEX);
@@ -37,7 +37,7 @@ final class StatisticsTransfer extends AbstractTransfer
 
     // Content
     public const string CONTENT = 'Content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     public ?string $Content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -46,7 +46,7 @@ final class StatisticsTransfer extends AbstractTransfer
 
     // Cubes
     public const string CUBES = 'Cubes';
-    protected const int CUBES_INDEX = 2;
+    private const int CUBES_INDEX = 2;
 
     public ?string $Cubes {
         get => $this->getData(self::CUBES_INDEX);
@@ -55,7 +55,7 @@ final class StatisticsTransfer extends AbstractTransfer
 
     // Information
     public const string INFORMATION = 'Information';
-    protected const int INFORMATION_INDEX = 3;
+    private const int INFORMATION_INDEX = 3;
 
     public ?string $Information {
         get => $this->getData(self::INFORMATION_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/StatusTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/StatusTransfer.php
@@ -27,7 +27,7 @@ final class StatusTransfer extends AbstractTransfer
 
     // Code
     public const string CODE = 'Code';
-    protected const int CODE_INDEX = 0;
+    private const int CODE_INDEX = 0;
 
     public ?int $Code {
         get => $this->getData(self::CODE_INDEX);
@@ -36,7 +36,7 @@ final class StatusTransfer extends AbstractTransfer
 
     // Content
     public const string CONTENT = 'Content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     public ?string $Content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -45,7 +45,7 @@ final class StatusTransfer extends AbstractTransfer
 
     // Type
     public const string TYPE = 'Type';
-    protected const int TYPE_INDEX = 2;
+    private const int TYPE_INDEX = 2;
 
     public ?string $Type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/TablesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/TablesTransfer.php
@@ -27,7 +27,7 @@ final class TablesTransfer extends AbstractTransfer
 
     // Code
     public const string CODE = 'Code';
-    protected const int CODE_INDEX = 0;
+    private const int CODE_INDEX = 0;
 
     public ?string $Code {
         get => $this->getData(self::CODE_INDEX);
@@ -36,7 +36,7 @@ final class TablesTransfer extends AbstractTransfer
 
     // Content
     public const string CONTENT = 'Content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     public ?string $Content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -45,7 +45,7 @@ final class TablesTransfer extends AbstractTransfer
 
     // Time
     public const string TIME = 'Time';
-    protected const int TIME_INDEX = 2;
+    private const int TIME_INDEX = 2;
 
     public ?string $Time {
         get => $this->getData(self::TIME_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Destatis/VariablesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Destatis/VariablesTransfer.php
@@ -29,7 +29,7 @@ final class VariablesTransfer extends AbstractTransfer
 
     // Code
     public const string CODE = 'Code';
-    protected const int CODE_INDEX = 0;
+    private const int CODE_INDEX = 0;
 
     public ?string $Code {
         get => $this->getData(self::CODE_INDEX);
@@ -38,7 +38,7 @@ final class VariablesTransfer extends AbstractTransfer
 
     // Content
     public const string CONTENT = 'Content';
-    protected const int CONTENT_INDEX = 1;
+    private const int CONTENT_INDEX = 1;
 
     public ?string $Content {
         get => $this->getData(self::CONTENT_INDEX);
@@ -47,7 +47,7 @@ final class VariablesTransfer extends AbstractTransfer
 
     // Information
     public const string INFORMATION = 'Information';
-    protected const int INFORMATION_INDEX = 2;
+    private const int INFORMATION_INDEX = 2;
 
     public ?string $Information {
         get => $this->getData(self::INFORMATION_INDEX);
@@ -56,7 +56,7 @@ final class VariablesTransfer extends AbstractTransfer
 
     // Type
     public const string TYPE = 'Type';
-    protected const int TYPE_INDEX = 3;
+    private const int TYPE_INDEX = 3;
 
     public ?string $Type {
         get => $this->getData(self::TYPE_INDEX);
@@ -65,7 +65,7 @@ final class VariablesTransfer extends AbstractTransfer
 
     // Values
     public const string VALUES = 'Values';
-    protected const int VALUES_INDEX = 4;
+    private const int VALUES_INDEX = 4;
 
     public ?string $Values {
         get => $this->getData(self::VALUES_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Frankfurter/ExchangeRateTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Frankfurter/ExchangeRateTransfer.php
@@ -29,7 +29,7 @@ final class ExchangeRateTransfer extends AbstractTransfer
 
     // amount
     public const string AMOUNT = 'amount';
-    protected const int AMOUNT_INDEX = 0;
+    private const int AMOUNT_INDEX = 0;
 
     public ?int $amount {
         get => $this->getData(self::AMOUNT_INDEX);
@@ -38,7 +38,7 @@ final class ExchangeRateTransfer extends AbstractTransfer
 
     // base
     public const string BASE = 'base';
-    protected const int BASE_INDEX = 1;
+    private const int BASE_INDEX = 1;
 
     public ?string $base {
         get => $this->getData(self::BASE_INDEX);
@@ -47,7 +47,7 @@ final class ExchangeRateTransfer extends AbstractTransfer
 
     // date
     public const string DATE = 'date';
-    protected const int DATE_INDEX = 2;
+    private const int DATE_INDEX = 2;
 
     public ?string $date {
         get => $this->getData(self::DATE_INDEX);
@@ -57,7 +57,7 @@ final class ExchangeRateTransfer extends AbstractTransfer
     // rates
     #[PropertyTypeAttribute(RatesTransfer::class)]
     public const string RATES = 'rates';
-    protected const int RATES_INDEX = 3;
+    private const int RATES_INDEX = 3;
 
     public ?RatesTransfer $rates {
         get => $this->getData(self::RATES_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Frankfurter/RatesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Frankfurter/RatesTransfer.php
@@ -54,7 +54,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // AUD
     public const string AUD = 'AUD';
-    protected const int AUD_INDEX = 0;
+    private const int AUD_INDEX = 0;
 
     public ?float $AUD {
         get => $this->getData(self::AUD_INDEX);
@@ -63,7 +63,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // BGN
     public const string BGN = 'BGN';
-    protected const int BGN_INDEX = 1;
+    private const int BGN_INDEX = 1;
 
     public ?float $BGN {
         get => $this->getData(self::BGN_INDEX);
@@ -72,7 +72,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // BRL
     public const string BRL = 'BRL';
-    protected const int BRL_INDEX = 2;
+    private const int BRL_INDEX = 2;
 
     public ?float $BRL {
         get => $this->getData(self::BRL_INDEX);
@@ -81,7 +81,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // CAD
     public const string CAD = 'CAD';
-    protected const int CAD_INDEX = 3;
+    private const int CAD_INDEX = 3;
 
     public ?float $CAD {
         get => $this->getData(self::CAD_INDEX);
@@ -90,7 +90,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // CHF
     public const string CHF = 'CHF';
-    protected const int CHF_INDEX = 4;
+    private const int CHF_INDEX = 4;
 
     public ?float $CHF {
         get => $this->getData(self::CHF_INDEX);
@@ -99,7 +99,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // CNY
     public const string CNY = 'CNY';
-    protected const int CNY_INDEX = 5;
+    private const int CNY_INDEX = 5;
 
     public ?float $CNY {
         get => $this->getData(self::CNY_INDEX);
@@ -108,7 +108,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // CZK
     public const string CZK = 'CZK';
-    protected const int CZK_INDEX = 6;
+    private const int CZK_INDEX = 6;
 
     public ?float $CZK {
         get => $this->getData(self::CZK_INDEX);
@@ -117,7 +117,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // DKK
     public const string DKK = 'DKK';
-    protected const int DKK_INDEX = 7;
+    private const int DKK_INDEX = 7;
 
     public ?float $DKK {
         get => $this->getData(self::DKK_INDEX);
@@ -126,7 +126,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // GBP
     public const string GBP = 'GBP';
-    protected const int GBP_INDEX = 8;
+    private const int GBP_INDEX = 8;
 
     public ?float $GBP {
         get => $this->getData(self::GBP_INDEX);
@@ -135,7 +135,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // HKD
     public const string HKD = 'HKD';
-    protected const int HKD_INDEX = 9;
+    private const int HKD_INDEX = 9;
 
     public ?float $HKD {
         get => $this->getData(self::HKD_INDEX);
@@ -144,7 +144,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // HUF
     public const string HUF = 'HUF';
-    protected const int HUF_INDEX = 10;
+    private const int HUF_INDEX = 10;
 
     public ?float $HUF {
         get => $this->getData(self::HUF_INDEX);
@@ -153,7 +153,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // IDR
     public const string IDR = 'IDR';
-    protected const int IDR_INDEX = 11;
+    private const int IDR_INDEX = 11;
 
     public ?int $IDR {
         get => $this->getData(self::IDR_INDEX);
@@ -162,7 +162,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // ILS
     public const string ILS = 'ILS';
-    protected const int ILS_INDEX = 12;
+    private const int ILS_INDEX = 12;
 
     public ?float $ILS {
         get => $this->getData(self::ILS_INDEX);
@@ -171,7 +171,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // INR
     public const string INR = 'INR';
-    protected const int INR_INDEX = 13;
+    private const int INR_INDEX = 13;
 
     public ?float $INR {
         get => $this->getData(self::INR_INDEX);
@@ -180,7 +180,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // ISK
     public const string ISK = 'ISK';
-    protected const int ISK_INDEX = 14;
+    private const int ISK_INDEX = 14;
 
     public ?float $ISK {
         get => $this->getData(self::ISK_INDEX);
@@ -189,7 +189,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // JPY
     public const string JPY = 'JPY';
-    protected const int JPY_INDEX = 15;
+    private const int JPY_INDEX = 15;
 
     public ?float $JPY {
         get => $this->getData(self::JPY_INDEX);
@@ -198,7 +198,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // KRW
     public const string KRW = 'KRW';
-    protected const int KRW_INDEX = 16;
+    private const int KRW_INDEX = 16;
 
     public ?float $KRW {
         get => $this->getData(self::KRW_INDEX);
@@ -207,7 +207,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // MXN
     public const string MXN = 'MXN';
-    protected const int MXN_INDEX = 17;
+    private const int MXN_INDEX = 17;
 
     public ?float $MXN {
         get => $this->getData(self::MXN_INDEX);
@@ -216,7 +216,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // MYR
     public const string MYR = 'MYR';
-    protected const int MYR_INDEX = 18;
+    private const int MYR_INDEX = 18;
 
     public ?float $MYR {
         get => $this->getData(self::MYR_INDEX);
@@ -225,7 +225,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // NOK
     public const string NOK = 'NOK';
-    protected const int NOK_INDEX = 19;
+    private const int NOK_INDEX = 19;
 
     public ?float $NOK {
         get => $this->getData(self::NOK_INDEX);
@@ -234,7 +234,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // NZD
     public const string NZD = 'NZD';
-    protected const int NZD_INDEX = 20;
+    private const int NZD_INDEX = 20;
 
     public ?float $NZD {
         get => $this->getData(self::NZD_INDEX);
@@ -243,7 +243,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // PHP
     public const string PHP = 'PHP';
-    protected const int PHP_INDEX = 21;
+    private const int PHP_INDEX = 21;
 
     public ?float $PHP {
         get => $this->getData(self::PHP_INDEX);
@@ -252,7 +252,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // PLN
     public const string PLN = 'PLN';
-    protected const int PLN_INDEX = 22;
+    private const int PLN_INDEX = 22;
 
     public ?float $PLN {
         get => $this->getData(self::PLN_INDEX);
@@ -261,7 +261,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // RON
     public const string RON = 'RON';
-    protected const int RON_INDEX = 23;
+    private const int RON_INDEX = 23;
 
     public ?float $RON {
         get => $this->getData(self::RON_INDEX);
@@ -270,7 +270,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // SEK
     public const string SEK = 'SEK';
-    protected const int SEK_INDEX = 24;
+    private const int SEK_INDEX = 24;
 
     public ?float $SEK {
         get => $this->getData(self::SEK_INDEX);
@@ -279,7 +279,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // SGD
     public const string SGD = 'SGD';
-    protected const int SGD_INDEX = 25;
+    private const int SGD_INDEX = 25;
 
     public ?float $SGD {
         get => $this->getData(self::SGD_INDEX);
@@ -288,7 +288,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // THB
     public const string THB = 'THB';
-    protected const int THB_INDEX = 26;
+    private const int THB_INDEX = 26;
 
     public ?float $THB {
         get => $this->getData(self::THB_INDEX);
@@ -297,7 +297,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // TRY
     public const string TRY = 'TRY';
-    protected const int TRY_INDEX = 27;
+    private const int TRY_INDEX = 27;
 
     public ?float $TRY {
         get => $this->getData(self::TRY_INDEX);
@@ -306,7 +306,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // USD
     public const string USD = 'USD';
-    protected const int USD_INDEX = 28;
+    private const int USD_INDEX = 28;
 
     public ?float $USD {
         get => $this->getData(self::USD_INDEX);
@@ -315,7 +315,7 @@ final class RatesTransfer extends AbstractTransfer
 
     // ZAR
     public const string ZAR = 'ZAR';
-    protected const int ZAR_INDEX = 29;
+    private const int ZAR_INDEX = 29;
 
     public ?float $ZAR {
         get => $this->getData(self::ZAR_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/PriceTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/PriceTransfer.php
@@ -26,7 +26,7 @@ final class PriceTransfer extends AbstractTransfer
 
     // currency
     public const string CURRENCY = 'currency';
-    protected const int CURRENCY_INDEX = 0;
+    private const int CURRENCY_INDEX = 0;
 
     public ?string $currency {
         get => $this->getData(self::CURRENCY_INDEX);
@@ -35,7 +35,7 @@ final class PriceTransfer extends AbstractTransfer
 
     // value
     public const string VALUE = 'value';
-    protected const int VALUE_INDEX = 1;
+    private const int VALUE_INDEX = 1;
 
     public ?string $value {
         get => $this->getData(self::VALUE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/ProductTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/GoogleShoppingContent/ProductTransfer.php
@@ -53,7 +53,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // ageGroup
     public const string AGE_GROUP = 'ageGroup';
-    protected const int AGE_GROUP_INDEX = 0;
+    private const int AGE_GROUP_INDEX = 0;
 
     public ?string $ageGroup {
         get => $this->getData(self::AGE_GROUP_INDEX);
@@ -62,7 +62,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // availability
     public const string AVAILABILITY = 'availability';
-    protected const int AVAILABILITY_INDEX = 1;
+    private const int AVAILABILITY_INDEX = 1;
 
     public ?string $availability {
         get => $this->getData(self::AVAILABILITY_INDEX);
@@ -72,7 +72,7 @@ final class ProductTransfer extends AbstractTransfer
     // availabilityDate
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string AVAILABILITY_DATE = 'availabilityDate';
-    protected const int AVAILABILITY_DATE_INDEX = 2;
+    private const int AVAILABILITY_DATE_INDEX = 2;
 
     public ?DateTime $availabilityDate {
         get => $this->getData(self::AVAILABILITY_DATE_INDEX);
@@ -81,7 +81,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // brand
     public const string BRAND = 'brand';
-    protected const int BRAND_INDEX = 3;
+    private const int BRAND_INDEX = 3;
 
     public ?string $brand {
         get => $this->getData(self::BRAND_INDEX);
@@ -90,7 +90,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // channel
     public const string CHANNEL = 'channel';
-    protected const int CHANNEL_INDEX = 4;
+    private const int CHANNEL_INDEX = 4;
 
     public ?string $channel {
         get => $this->getData(self::CHANNEL_INDEX);
@@ -99,7 +99,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // color
     public const string COLOR = 'color';
-    protected const int COLOR_INDEX = 5;
+    private const int COLOR_INDEX = 5;
 
     public ?string $color {
         get => $this->getData(self::COLOR_INDEX);
@@ -108,7 +108,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // condition
     public const string CONDITION = 'condition';
-    protected const int CONDITION_INDEX = 6;
+    private const int CONDITION_INDEX = 6;
 
     public ?string $condition {
         get => $this->getData(self::CONDITION_INDEX);
@@ -117,7 +117,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // contentLanguage
     public const string CONTENT_LANGUAGE = 'contentLanguage';
-    protected const int CONTENT_LANGUAGE_INDEX = 7;
+    private const int CONTENT_LANGUAGE_INDEX = 7;
 
     public ?string $contentLanguage {
         get => $this->getData(self::CONTENT_LANGUAGE_INDEX);
@@ -126,7 +126,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const int DESCRIPTION_INDEX = 8;
+    private const int DESCRIPTION_INDEX = 8;
 
     public ?string $description {
         get => $this->getData(self::DESCRIPTION_INDEX);
@@ -135,7 +135,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // feedLabel
     public const string FEED_LABEL = 'feedLabel';
-    protected const int FEED_LABEL_INDEX = 9;
+    private const int FEED_LABEL_INDEX = 9;
 
     public ?string $feedLabel {
         get => $this->getData(self::FEED_LABEL_INDEX);
@@ -144,7 +144,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // gender
     public const string GENDER = 'gender';
-    protected const int GENDER_INDEX = 10;
+    private const int GENDER_INDEX = 10;
 
     public ?string $gender {
         get => $this->getData(self::GENDER_INDEX);
@@ -153,7 +153,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // googleProductCategory
     public const string GOOGLE_PRODUCT_CATEGORY = 'googleProductCategory';
-    protected const int GOOGLE_PRODUCT_CATEGORY_INDEX = 11;
+    private const int GOOGLE_PRODUCT_CATEGORY_INDEX = 11;
 
     public ?string $googleProductCategory {
         get => $this->getData(self::GOOGLE_PRODUCT_CATEGORY_INDEX);
@@ -162,7 +162,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // gtin
     public const string GTIN = 'gtin';
-    protected const int GTIN_INDEX = 12;
+    private const int GTIN_INDEX = 12;
 
     public ?string $gtin {
         get => $this->getData(self::GTIN_INDEX);
@@ -171,7 +171,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // id
     public const string ID = 'id';
-    protected const int ID_INDEX = 13;
+    private const int ID_INDEX = 13;
 
     public ?string $id {
         get => $this->getData(self::ID_INDEX);
@@ -180,7 +180,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // imageLink
     public const string IMAGE_LINK = 'imageLink';
-    protected const int IMAGE_LINK_INDEX = 14;
+    private const int IMAGE_LINK_INDEX = 14;
 
     public ?string $imageLink {
         get => $this->getData(self::IMAGE_LINK_INDEX);
@@ -189,7 +189,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // itemGroupId
     public const string ITEM_GROUP_ID = 'itemGroupId';
-    protected const int ITEM_GROUP_ID_INDEX = 15;
+    private const int ITEM_GROUP_ID_INDEX = 15;
 
     public ?string $itemGroupId {
         get => $this->getData(self::ITEM_GROUP_ID_INDEX);
@@ -198,7 +198,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // kind
     public const string KIND = 'kind';
-    protected const int KIND_INDEX = 16;
+    private const int KIND_INDEX = 16;
 
     public ?string $kind {
         get => $this->getData(self::KIND_INDEX);
@@ -207,7 +207,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // link
     public const string LINK = 'link';
-    protected const int LINK_INDEX = 17;
+    private const int LINK_INDEX = 17;
 
     public ?string $link {
         get => $this->getData(self::LINK_INDEX);
@@ -216,7 +216,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // mpn
     public const string MPN = 'mpn';
-    protected const int MPN_INDEX = 18;
+    private const int MPN_INDEX = 18;
 
     public ?string $mpn {
         get => $this->getData(self::MPN_INDEX);
@@ -225,7 +225,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // offerId
     public const string OFFER_ID = 'offerId';
-    protected const int OFFER_ID_INDEX = 19;
+    private const int OFFER_ID_INDEX = 19;
 
     public ?string $offerId {
         get => $this->getData(self::OFFER_ID_INDEX);
@@ -235,7 +235,7 @@ final class ProductTransfer extends AbstractTransfer
     // price
     #[PropertyTypeAttribute(PriceTransfer::class)]
     public const string PRICE = 'price';
-    protected const int PRICE_INDEX = 20;
+    private const int PRICE_INDEX = 20;
 
     public ?PriceTransfer $price {
         get => $this->getData(self::PRICE_INDEX);
@@ -245,7 +245,7 @@ final class ProductTransfer extends AbstractTransfer
     // sizes
     #[ArrayPropertyTypeAttribute]
     public const string SIZES = 'sizes';
-    protected const int SIZES_INDEX = 21;
+    private const int SIZES_INDEX = 21;
 
     /** @var array<int|string,mixed> */
     public array $sizes {
@@ -255,7 +255,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // source
     public const string SOURCE = 'source';
-    protected const int SOURCE_INDEX = 22;
+    private const int SOURCE_INDEX = 22;
 
     public ?string $source {
         get => $this->getData(self::SOURCE_INDEX);
@@ -264,7 +264,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // targetCountry
     public const string TARGET_COUNTRY = 'targetCountry';
-    protected const int TARGET_COUNTRY_INDEX = 23;
+    private const int TARGET_COUNTRY_INDEX = 23;
 
     public ?string $targetCountry {
         get => $this->getData(self::TARGET_COUNTRY_INDEX);
@@ -273,7 +273,7 @@ final class ProductTransfer extends AbstractTransfer
 
     // title
     public const string TITLE = 'title';
-    protected const int TITLE_INDEX = 24;
+    private const int TITLE_INDEX = 24;
 
     public ?string $title {
         get => $this->getData(self::TITLE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/AsteroidTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/AsteroidTransfer.php
@@ -39,7 +39,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // absolute_magnitude_h
     public const string ABSOLUTE_MAGNITUDE_H = 'absolute_magnitude_h';
-    protected const int ABSOLUTE_MAGNITUDE_H_INDEX = 0;
+    private const int ABSOLUTE_MAGNITUDE_H_INDEX = 0;
 
     public ?float $absolute_magnitude_h {
         get => $this->getData(self::ABSOLUTE_MAGNITUDE_H_INDEX);
@@ -49,7 +49,7 @@ final class AsteroidTransfer extends AbstractTransfer
     // close_approach_data
     #[CollectionPropertyTypeAttribute(CloseApproachDataTransfer::class)]
     public const string CLOSE_APPROACH_DATA = 'close_approach_data';
-    protected const int CLOSE_APPROACH_DATA_INDEX = 1;
+    private const int CLOSE_APPROACH_DATA_INDEX = 1;
 
     /** @var \ArrayObject<int,CloseApproachDataTransfer> */
     public ArrayObject $close_approach_data {
@@ -59,7 +59,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // designation
     public const string DESIGNATION = 'designation';
-    protected const int DESIGNATION_INDEX = 2;
+    private const int DESIGNATION_INDEX = 2;
 
     public ?string $designation {
         get => $this->getData(self::DESIGNATION_INDEX);
@@ -69,7 +69,7 @@ final class AsteroidTransfer extends AbstractTransfer
     // estimated_diameter
     #[PropertyTypeAttribute(EstimatedDiameterTransfer::class)]
     public const string ESTIMATED_DIAMETER = 'estimated_diameter';
-    protected const int ESTIMATED_DIAMETER_INDEX = 3;
+    private const int ESTIMATED_DIAMETER_INDEX = 3;
 
     public ?EstimatedDiameterTransfer $estimated_diameter {
         get => $this->getData(self::ESTIMATED_DIAMETER_INDEX);
@@ -78,7 +78,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // id
     public const string ID = 'id';
-    protected const int ID_INDEX = 4;
+    private const int ID_INDEX = 4;
 
     public ?string $id {
         get => $this->getData(self::ID_INDEX);
@@ -87,7 +87,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // is_potentially_hazardous_asteroid
     public const string IS_POTENTIALLY_HAZARDOUS_ASTEROID = 'is_potentially_hazardous_asteroid';
-    protected const int IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX = 5;
+    private const int IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX = 5;
 
     public ?bool $is_potentially_hazardous_asteroid {
         get => $this->getData(self::IS_POTENTIALLY_HAZARDOUS_ASTEROID_INDEX);
@@ -96,7 +96,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // is_sentry_object
     public const string IS_SENTRY_OBJECT = 'is_sentry_object';
-    protected const int IS_SENTRY_OBJECT_INDEX = 6;
+    private const int IS_SENTRY_OBJECT_INDEX = 6;
 
     public ?bool $is_sentry_object {
         get => $this->getData(self::IS_SENTRY_OBJECT_INDEX);
@@ -106,7 +106,7 @@ final class AsteroidTransfer extends AbstractTransfer
     // links
     #[PropertyTypeAttribute(LinksTransfer::class)]
     public const string LINKS = 'links';
-    protected const int LINKS_INDEX = 7;
+    private const int LINKS_INDEX = 7;
 
     public ?LinksTransfer $links {
         get => $this->getData(self::LINKS_INDEX);
@@ -115,7 +115,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 8;
+    private const int NAME_INDEX = 8;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);
@@ -124,7 +124,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // nasa_jpl_url
     public const string NASA_JPL_URL = 'nasa_jpl_url';
-    protected const int NASA_JPL_URL_INDEX = 9;
+    private const int NASA_JPL_URL_INDEX = 9;
 
     public ?string $nasa_jpl_url {
         get => $this->getData(self::NASA_JPL_URL_INDEX);
@@ -133,7 +133,7 @@ final class AsteroidTransfer extends AbstractTransfer
 
     // neo_reference_id
     public const string NEO_REFERENCE_ID = 'neo_reference_id';
-    protected const int NEO_REFERENCE_ID_INDEX = 10;
+    private const int NEO_REFERENCE_ID_INDEX = 10;
 
     public ?string $neo_reference_id {
         get => $this->getData(self::NEO_REFERENCE_ID_INDEX);
@@ -143,7 +143,7 @@ final class AsteroidTransfer extends AbstractTransfer
     // orbital_data
     #[PropertyTypeAttribute(OrbitalDataTransfer::class)]
     public const string ORBITAL_DATA = 'orbital_data';
-    protected const int ORBITAL_DATA_INDEX = 11;
+    private const int ORBITAL_DATA_INDEX = 11;
 
     public ?OrbitalDataTransfer $orbital_data {
         get => $this->getData(self::ORBITAL_DATA_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/CloseApproachDataTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/CloseApproachDataTransfer.php
@@ -31,7 +31,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
 
     // close_approach_date
     public const string CLOSE_APPROACH_DATE = 'close_approach_date';
-    protected const int CLOSE_APPROACH_DATE_INDEX = 0;
+    private const int CLOSE_APPROACH_DATE_INDEX = 0;
 
     public ?string $close_approach_date {
         get => $this->getData(self::CLOSE_APPROACH_DATE_INDEX);
@@ -40,7 +40,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
 
     // close_approach_date_full
     public const string CLOSE_APPROACH_DATE_FULL = 'close_approach_date_full';
-    protected const int CLOSE_APPROACH_DATE_FULL_INDEX = 1;
+    private const int CLOSE_APPROACH_DATE_FULL_INDEX = 1;
 
     public ?string $close_approach_date_full {
         get => $this->getData(self::CLOSE_APPROACH_DATE_FULL_INDEX);
@@ -49,7 +49,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
 
     // epoch_date_close_approach
     public const string EPOCH_DATE_CLOSE_APPROACH = 'epoch_date_close_approach';
-    protected const int EPOCH_DATE_CLOSE_APPROACH_INDEX = 2;
+    private const int EPOCH_DATE_CLOSE_APPROACH_INDEX = 2;
 
     public ?int $epoch_date_close_approach {
         get => $this->getData(self::EPOCH_DATE_CLOSE_APPROACH_INDEX);
@@ -59,7 +59,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
     // miss_distance
     #[PropertyTypeAttribute(MissDistanceTransfer::class)]
     public const string MISS_DISTANCE = 'miss_distance';
-    protected const int MISS_DISTANCE_INDEX = 3;
+    private const int MISS_DISTANCE_INDEX = 3;
 
     public ?MissDistanceTransfer $miss_distance {
         get => $this->getData(self::MISS_DISTANCE_INDEX);
@@ -68,7 +68,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
 
     // orbiting_body
     public const string ORBITING_BODY = 'orbiting_body';
-    protected const int ORBITING_BODY_INDEX = 4;
+    private const int ORBITING_BODY_INDEX = 4;
 
     public ?string $orbiting_body {
         get => $this->getData(self::ORBITING_BODY_INDEX);
@@ -78,7 +78,7 @@ final class CloseApproachDataTransfer extends AbstractTransfer
     // relative_velocity
     #[PropertyTypeAttribute(RelativeVelocityTransfer::class)]
     public const string RELATIVE_VELOCITY = 'relative_velocity';
-    protected const int RELATIVE_VELOCITY_INDEX = 5;
+    private const int RELATIVE_VELOCITY_INDEX = 5;
 
     public ?RelativeVelocityTransfer $relative_velocity {
         get => $this->getData(self::RELATIVE_VELOCITY_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/EstimatedDiameterTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/EstimatedDiameterTransfer.php
@@ -30,7 +30,7 @@ final class EstimatedDiameterTransfer extends AbstractTransfer
     // feet
     #[PropertyTypeAttribute(FeetTransfer::class)]
     public const string FEET = 'feet';
-    protected const int FEET_INDEX = 0;
+    private const int FEET_INDEX = 0;
 
     public ?FeetTransfer $feet {
         get => $this->getData(self::FEET_INDEX);
@@ -40,7 +40,7 @@ final class EstimatedDiameterTransfer extends AbstractTransfer
     // kilometers
     #[PropertyTypeAttribute(KilometersTransfer::class)]
     public const string KILOMETERS = 'kilometers';
-    protected const int KILOMETERS_INDEX = 1;
+    private const int KILOMETERS_INDEX = 1;
 
     public ?KilometersTransfer $kilometers {
         get => $this->getData(self::KILOMETERS_INDEX);
@@ -50,7 +50,7 @@ final class EstimatedDiameterTransfer extends AbstractTransfer
     // meters
     #[PropertyTypeAttribute(MetersTransfer::class)]
     public const string METERS = 'meters';
-    protected const int METERS_INDEX = 2;
+    private const int METERS_INDEX = 2;
 
     public ?MetersTransfer $meters {
         get => $this->getData(self::METERS_INDEX);
@@ -60,7 +60,7 @@ final class EstimatedDiameterTransfer extends AbstractTransfer
     // miles
     #[PropertyTypeAttribute(MilesTransfer::class)]
     public const string MILES = 'miles';
-    protected const int MILES_INDEX = 3;
+    private const int MILES_INDEX = 3;
 
     public ?MilesTransfer $miles {
         get => $this->getData(self::MILES_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/FeetTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/FeetTransfer.php
@@ -26,7 +26,7 @@ final class FeetTransfer extends AbstractTransfer
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
+    private const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
         get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
@@ -35,7 +35,7 @@ final class FeetTransfer extends AbstractTransfer
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
+    private const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
         get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/KilometersTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/KilometersTransfer.php
@@ -26,7 +26,7 @@ final class KilometersTransfer extends AbstractTransfer
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
+    private const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
         get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
@@ -35,7 +35,7 @@ final class KilometersTransfer extends AbstractTransfer
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
+    private const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
         get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/LinksTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/LinksTransfer.php
@@ -25,7 +25,7 @@ final class LinksTransfer extends AbstractTransfer
 
     // self
     public const string SELF = 'self';
-    protected const int SELF_INDEX = 0;
+    private const int SELF_INDEX = 0;
 
     public ?string $self {
         get => $this->getData(self::SELF_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MetersTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MetersTransfer.php
@@ -26,7 +26,7 @@ final class MetersTransfer extends AbstractTransfer
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
+    private const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
         get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
@@ -35,7 +35,7 @@ final class MetersTransfer extends AbstractTransfer
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
+    private const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
         get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MilesTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MilesTransfer.php
@@ -26,7 +26,7 @@ final class MilesTransfer extends AbstractTransfer
 
     // estimated_diameter_max
     public const string ESTIMATED_DIAMETER_MAX = 'estimated_diameter_max';
-    protected const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
+    private const int ESTIMATED_DIAMETER_MAX_INDEX = 0;
 
     public ?float $estimated_diameter_max {
         get => $this->getData(self::ESTIMATED_DIAMETER_MAX_INDEX);
@@ -35,7 +35,7 @@ final class MilesTransfer extends AbstractTransfer
 
     // estimated_diameter_min
     public const string ESTIMATED_DIAMETER_MIN = 'estimated_diameter_min';
-    protected const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
+    private const int ESTIMATED_DIAMETER_MIN_INDEX = 1;
 
     public ?float $estimated_diameter_min {
         get => $this->getData(self::ESTIMATED_DIAMETER_MIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/MissDistanceTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/MissDistanceTransfer.php
@@ -28,7 +28,7 @@ final class MissDistanceTransfer extends AbstractTransfer
 
     // astronomical
     public const string ASTRONOMICAL = 'astronomical';
-    protected const int ASTRONOMICAL_INDEX = 0;
+    private const int ASTRONOMICAL_INDEX = 0;
 
     public ?string $astronomical {
         get => $this->getData(self::ASTRONOMICAL_INDEX);
@@ -37,7 +37,7 @@ final class MissDistanceTransfer extends AbstractTransfer
 
     // kilometers
     public const string KILOMETERS = 'kilometers';
-    protected const int KILOMETERS_INDEX = 1;
+    private const int KILOMETERS_INDEX = 1;
 
     public ?string $kilometers {
         get => $this->getData(self::KILOMETERS_INDEX);
@@ -46,7 +46,7 @@ final class MissDistanceTransfer extends AbstractTransfer
 
     // lunar
     public const string LUNAR = 'lunar';
-    protected const int LUNAR_INDEX = 2;
+    private const int LUNAR_INDEX = 2;
 
     public ?string $lunar {
         get => $this->getData(self::LUNAR_INDEX);
@@ -55,7 +55,7 @@ final class MissDistanceTransfer extends AbstractTransfer
 
     // miles
     public const string MILES = 'miles';
-    protected const int MILES_INDEX = 3;
+    private const int MILES_INDEX = 3;
 
     public ?string $miles {
         get => $this->getData(self::MILES_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitClassTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitClassTransfer.php
@@ -27,7 +27,7 @@ final class OrbitClassTransfer extends AbstractTransfer
 
     // orbit_class_description
     public const string ORBIT_CLASS_DESCRIPTION = 'orbit_class_description';
-    protected const int ORBIT_CLASS_DESCRIPTION_INDEX = 0;
+    private const int ORBIT_CLASS_DESCRIPTION_INDEX = 0;
 
     public ?string $orbit_class_description {
         get => $this->getData(self::ORBIT_CLASS_DESCRIPTION_INDEX);
@@ -36,7 +36,7 @@ final class OrbitClassTransfer extends AbstractTransfer
 
     // orbit_class_range
     public const string ORBIT_CLASS_RANGE = 'orbit_class_range';
-    protected const int ORBIT_CLASS_RANGE_INDEX = 1;
+    private const int ORBIT_CLASS_RANGE_INDEX = 1;
 
     public ?string $orbit_class_range {
         get => $this->getData(self::ORBIT_CLASS_RANGE_INDEX);
@@ -45,7 +45,7 @@ final class OrbitClassTransfer extends AbstractTransfer
 
     // orbit_class_type
     public const string ORBIT_CLASS_TYPE = 'orbit_class_type';
-    protected const int ORBIT_CLASS_TYPE_INDEX = 2;
+    private const int ORBIT_CLASS_TYPE_INDEX = 2;
 
     public ?string $orbit_class_type {
         get => $this->getData(self::ORBIT_CLASS_TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitalDataTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/OrbitalDataTransfer.php
@@ -48,7 +48,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // aphelion_distance
     public const string APHELION_DISTANCE = 'aphelion_distance';
-    protected const int APHELION_DISTANCE_INDEX = 0;
+    private const int APHELION_DISTANCE_INDEX = 0;
 
     public ?string $aphelion_distance {
         get => $this->getData(self::APHELION_DISTANCE_INDEX);
@@ -57,7 +57,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // ascending_node_longitude
     public const string ASCENDING_NODE_LONGITUDE = 'ascending_node_longitude';
-    protected const int ASCENDING_NODE_LONGITUDE_INDEX = 1;
+    private const int ASCENDING_NODE_LONGITUDE_INDEX = 1;
 
     public ?string $ascending_node_longitude {
         get => $this->getData(self::ASCENDING_NODE_LONGITUDE_INDEX);
@@ -66,7 +66,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // data_arc_in_days
     public const string DATA_ARC_IN_DAYS = 'data_arc_in_days';
-    protected const int DATA_ARC_IN_DAYS_INDEX = 2;
+    private const int DATA_ARC_IN_DAYS_INDEX = 2;
 
     public ?int $data_arc_in_days {
         get => $this->getData(self::DATA_ARC_IN_DAYS_INDEX);
@@ -75,7 +75,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // eccentricity
     public const string ECCENTRICITY = 'eccentricity';
-    protected const int ECCENTRICITY_INDEX = 3;
+    private const int ECCENTRICITY_INDEX = 3;
 
     public ?string $eccentricity {
         get => $this->getData(self::ECCENTRICITY_INDEX);
@@ -84,7 +84,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // epoch_osculation
     public const string EPOCH_OSCULATION = 'epoch_osculation';
-    protected const int EPOCH_OSCULATION_INDEX = 4;
+    private const int EPOCH_OSCULATION_INDEX = 4;
 
     public ?string $epoch_osculation {
         get => $this->getData(self::EPOCH_OSCULATION_INDEX);
@@ -93,7 +93,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // equinox
     public const string EQUINOX = 'equinox';
-    protected const int EQUINOX_INDEX = 5;
+    private const int EQUINOX_INDEX = 5;
 
     public ?string $equinox {
         get => $this->getData(self::EQUINOX_INDEX);
@@ -102,7 +102,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // first_observation_date
     public const string FIRST_OBSERVATION_DATE = 'first_observation_date';
-    protected const int FIRST_OBSERVATION_DATE_INDEX = 6;
+    private const int FIRST_OBSERVATION_DATE_INDEX = 6;
 
     public ?string $first_observation_date {
         get => $this->getData(self::FIRST_OBSERVATION_DATE_INDEX);
@@ -111,7 +111,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // inclination
     public const string INCLINATION = 'inclination';
-    protected const int INCLINATION_INDEX = 7;
+    private const int INCLINATION_INDEX = 7;
 
     public ?string $inclination {
         get => $this->getData(self::INCLINATION_INDEX);
@@ -120,7 +120,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // jupiter_tisserand_invariant
     public const string JUPITER_TISSERAND_INVARIANT = 'jupiter_tisserand_invariant';
-    protected const int JUPITER_TISSERAND_INVARIANT_INDEX = 8;
+    private const int JUPITER_TISSERAND_INVARIANT_INDEX = 8;
 
     public ?string $jupiter_tisserand_invariant {
         get => $this->getData(self::JUPITER_TISSERAND_INVARIANT_INDEX);
@@ -129,7 +129,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // last_observation_date
     public const string LAST_OBSERVATION_DATE = 'last_observation_date';
-    protected const int LAST_OBSERVATION_DATE_INDEX = 9;
+    private const int LAST_OBSERVATION_DATE_INDEX = 9;
 
     public ?string $last_observation_date {
         get => $this->getData(self::LAST_OBSERVATION_DATE_INDEX);
@@ -138,7 +138,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // mean_anomaly
     public const string MEAN_ANOMALY = 'mean_anomaly';
-    protected const int MEAN_ANOMALY_INDEX = 10;
+    private const int MEAN_ANOMALY_INDEX = 10;
 
     public ?string $mean_anomaly {
         get => $this->getData(self::MEAN_ANOMALY_INDEX);
@@ -147,7 +147,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // mean_motion
     public const string MEAN_MOTION = 'mean_motion';
-    protected const int MEAN_MOTION_INDEX = 11;
+    private const int MEAN_MOTION_INDEX = 11;
 
     public ?string $mean_motion {
         get => $this->getData(self::MEAN_MOTION_INDEX);
@@ -156,7 +156,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // minimum_orbit_intersection
     public const string MINIMUM_ORBIT_INTERSECTION = 'minimum_orbit_intersection';
-    protected const int MINIMUM_ORBIT_INTERSECTION_INDEX = 12;
+    private const int MINIMUM_ORBIT_INTERSECTION_INDEX = 12;
 
     public ?string $minimum_orbit_intersection {
         get => $this->getData(self::MINIMUM_ORBIT_INTERSECTION_INDEX);
@@ -165,7 +165,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // observations_used
     public const string OBSERVATIONS_USED = 'observations_used';
-    protected const int OBSERVATIONS_USED_INDEX = 13;
+    private const int OBSERVATIONS_USED_INDEX = 13;
 
     public ?int $observations_used {
         get => $this->getData(self::OBSERVATIONS_USED_INDEX);
@@ -175,7 +175,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
     // orbit_class
     #[PropertyTypeAttribute(OrbitClassTransfer::class)]
     public const string ORBIT_CLASS = 'orbit_class';
-    protected const int ORBIT_CLASS_INDEX = 14;
+    private const int ORBIT_CLASS_INDEX = 14;
 
     public ?OrbitClassTransfer $orbit_class {
         get => $this->getData(self::ORBIT_CLASS_INDEX);
@@ -184,7 +184,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // orbit_determination_date
     public const string ORBIT_DETERMINATION_DATE = 'orbit_determination_date';
-    protected const int ORBIT_DETERMINATION_DATE_INDEX = 15;
+    private const int ORBIT_DETERMINATION_DATE_INDEX = 15;
 
     public ?string $orbit_determination_date {
         get => $this->getData(self::ORBIT_DETERMINATION_DATE_INDEX);
@@ -193,7 +193,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // orbit_id
     public const string ORBIT_ID = 'orbit_id';
-    protected const int ORBIT_ID_INDEX = 16;
+    private const int ORBIT_ID_INDEX = 16;
 
     public ?string $orbit_id {
         get => $this->getData(self::ORBIT_ID_INDEX);
@@ -202,7 +202,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // orbit_uncertainty
     public const string ORBIT_UNCERTAINTY = 'orbit_uncertainty';
-    protected const int ORBIT_UNCERTAINTY_INDEX = 17;
+    private const int ORBIT_UNCERTAINTY_INDEX = 17;
 
     public ?string $orbit_uncertainty {
         get => $this->getData(self::ORBIT_UNCERTAINTY_INDEX);
@@ -211,7 +211,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // orbital_period
     public const string ORBITAL_PERIOD = 'orbital_period';
-    protected const int ORBITAL_PERIOD_INDEX = 18;
+    private const int ORBITAL_PERIOD_INDEX = 18;
 
     public ?string $orbital_period {
         get => $this->getData(self::ORBITAL_PERIOD_INDEX);
@@ -220,7 +220,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // perihelion_argument
     public const string PERIHELION_ARGUMENT = 'perihelion_argument';
-    protected const int PERIHELION_ARGUMENT_INDEX = 19;
+    private const int PERIHELION_ARGUMENT_INDEX = 19;
 
     public ?string $perihelion_argument {
         get => $this->getData(self::PERIHELION_ARGUMENT_INDEX);
@@ -229,7 +229,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // perihelion_distance
     public const string PERIHELION_DISTANCE = 'perihelion_distance';
-    protected const int PERIHELION_DISTANCE_INDEX = 20;
+    private const int PERIHELION_DISTANCE_INDEX = 20;
 
     public ?string $perihelion_distance {
         get => $this->getData(self::PERIHELION_DISTANCE_INDEX);
@@ -238,7 +238,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // perihelion_time
     public const string PERIHELION_TIME = 'perihelion_time';
-    protected const int PERIHELION_TIME_INDEX = 21;
+    private const int PERIHELION_TIME_INDEX = 21;
 
     public ?string $perihelion_time {
         get => $this->getData(self::PERIHELION_TIME_INDEX);
@@ -247,7 +247,7 @@ final class OrbitalDataTransfer extends AbstractTransfer
 
     // semi_major_axis
     public const string SEMI_MAJOR_AXIS = 'semi_major_axis';
-    protected const int SEMI_MAJOR_AXIS_INDEX = 22;
+    private const int SEMI_MAJOR_AXIS_INDEX = 22;
 
     public ?string $semi_major_axis {
         get => $this->getData(self::SEMI_MAJOR_AXIS_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/NasaNeo/RelativeVelocityTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/NasaNeo/RelativeVelocityTransfer.php
@@ -27,7 +27,7 @@ final class RelativeVelocityTransfer extends AbstractTransfer
 
     // kilometers_per_hour
     public const string KILOMETERS_PER_HOUR = 'kilometers_per_hour';
-    protected const int KILOMETERS_PER_HOUR_INDEX = 0;
+    private const int KILOMETERS_PER_HOUR_INDEX = 0;
 
     public ?string $kilometers_per_hour {
         get => $this->getData(self::KILOMETERS_PER_HOUR_INDEX);
@@ -36,7 +36,7 @@ final class RelativeVelocityTransfer extends AbstractTransfer
 
     // kilometers_per_second
     public const string KILOMETERS_PER_SECOND = 'kilometers_per_second';
-    protected const int KILOMETERS_PER_SECOND_INDEX = 1;
+    private const int KILOMETERS_PER_SECOND_INDEX = 1;
 
     public ?string $kilometers_per_second {
         get => $this->getData(self::KILOMETERS_PER_SECOND_INDEX);
@@ -45,7 +45,7 @@ final class RelativeVelocityTransfer extends AbstractTransfer
 
     // miles_per_hour
     public const string MILES_PER_HOUR = 'miles_per_hour';
-    protected const int MILES_PER_HOUR_INDEX = 2;
+    private const int MILES_PER_HOUR_INDEX = 2;
 
     public ?string $miles_per_hour {
         get => $this->getData(self::MILES_PER_HOUR_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/CloudsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/CloudsTransfer.php
@@ -25,7 +25,7 @@ final class CloudsTransfer extends AbstractTransfer
 
     // all
     public const string ALL = 'all';
-    protected const int ALL_INDEX = 0;
+    private const int ALL_INDEX = 0;
 
     public ?int $all {
         get => $this->getData(self::ALL_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/CoordTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/CoordTransfer.php
@@ -26,7 +26,7 @@ final class CoordTransfer extends AbstractTransfer
 
     // lat
     public const string LAT = 'lat';
-    protected const int LAT_INDEX = 0;
+    private const int LAT_INDEX = 0;
 
     public ?float $lat {
         get => $this->getData(self::LAT_INDEX);
@@ -35,7 +35,7 @@ final class CoordTransfer extends AbstractTransfer
 
     // lon
     public const string LON = 'lon';
-    protected const int LON_INDEX = 1;
+    private const int LON_INDEX = 1;
 
     public ?float $lon {
         get => $this->getData(self::LON_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/ForecastTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/ForecastTransfer.php
@@ -42,7 +42,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // base
     public const string BASE = 'base';
-    protected const int BASE_INDEX = 0;
+    private const int BASE_INDEX = 0;
 
     public ?string $base {
         get => $this->getData(self::BASE_INDEX);
@@ -52,7 +52,7 @@ final class ForecastTransfer extends AbstractTransfer
     // clouds
     #[PropertyTypeAttribute(CloudsTransfer::class)]
     public const string CLOUDS = 'clouds';
-    protected const int CLOUDS_INDEX = 1;
+    private const int CLOUDS_INDEX = 1;
 
     public ?CloudsTransfer $clouds {
         get => $this->getData(self::CLOUDS_INDEX);
@@ -61,7 +61,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // cod
     public const string COD = 'cod';
-    protected const int COD_INDEX = 2;
+    private const int COD_INDEX = 2;
 
     public ?int $cod {
         get => $this->getData(self::COD_INDEX);
@@ -71,7 +71,7 @@ final class ForecastTransfer extends AbstractTransfer
     // coord
     #[PropertyTypeAttribute(CoordTransfer::class)]
     public const string COORD = 'coord';
-    protected const int COORD_INDEX = 3;
+    private const int COORD_INDEX = 3;
 
     public ?CoordTransfer $coord {
         get => $this->getData(self::COORD_INDEX);
@@ -80,7 +80,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // dt
     public const string DT = 'dt';
-    protected const int DT_INDEX = 4;
+    private const int DT_INDEX = 4;
 
     public ?int $dt {
         get => $this->getData(self::DT_INDEX);
@@ -89,7 +89,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // id
     public const string ID = 'id';
-    protected const int ID_INDEX = 5;
+    private const int ID_INDEX = 5;
 
     public ?int $id {
         get => $this->getData(self::ID_INDEX);
@@ -99,7 +99,7 @@ final class ForecastTransfer extends AbstractTransfer
     // main
     #[PropertyTypeAttribute(MainTransfer::class)]
     public const string MAIN = 'main';
-    protected const int MAIN_INDEX = 6;
+    private const int MAIN_INDEX = 6;
 
     public ?MainTransfer $main {
         get => $this->getData(self::MAIN_INDEX);
@@ -108,7 +108,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 7;
+    private const int NAME_INDEX = 7;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);
@@ -118,7 +118,7 @@ final class ForecastTransfer extends AbstractTransfer
     // rain
     #[ArrayPropertyTypeAttribute]
     public const string RAIN = 'rain';
-    protected const int RAIN_INDEX = 8;
+    private const int RAIN_INDEX = 8;
 
     /** @var array<int|string,mixed> */
     public array $rain {
@@ -129,7 +129,7 @@ final class ForecastTransfer extends AbstractTransfer
     // sys
     #[PropertyTypeAttribute(SysTransfer::class)]
     public const string SYS = 'sys';
-    protected const int SYS_INDEX = 9;
+    private const int SYS_INDEX = 9;
 
     public ?SysTransfer $sys {
         get => $this->getData(self::SYS_INDEX);
@@ -138,7 +138,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // timezone
     public const string TIMEZONE = 'timezone';
-    protected const int TIMEZONE_INDEX = 10;
+    private const int TIMEZONE_INDEX = 10;
 
     public ?int $timezone {
         get => $this->getData(self::TIMEZONE_INDEX);
@@ -147,7 +147,7 @@ final class ForecastTransfer extends AbstractTransfer
 
     // visibility
     public const string VISIBILITY = 'visibility';
-    protected const int VISIBILITY_INDEX = 11;
+    private const int VISIBILITY_INDEX = 11;
 
     public ?int $visibility {
         get => $this->getData(self::VISIBILITY_INDEX);
@@ -157,7 +157,7 @@ final class ForecastTransfer extends AbstractTransfer
     // weather
     #[CollectionPropertyTypeAttribute(WeatherTransfer::class)]
     public const string WEATHER = 'weather';
-    protected const int WEATHER_INDEX = 12;
+    private const int WEATHER_INDEX = 12;
 
     /** @var \ArrayObject<int,WeatherTransfer> */
     public ArrayObject $weather {
@@ -168,7 +168,7 @@ final class ForecastTransfer extends AbstractTransfer
     // wind
     #[PropertyTypeAttribute(WindTransfer::class)]
     public const string WIND = 'wind';
-    protected const int WIND_INDEX = 13;
+    private const int WIND_INDEX = 13;
 
     public ?WindTransfer $wind {
         get => $this->getData(self::WIND_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/MainTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/MainTransfer.php
@@ -32,7 +32,7 @@ final class MainTransfer extends AbstractTransfer
 
     // feels_like
     public const string FEELS_LIKE = 'feels_like';
-    protected const int FEELS_LIKE_INDEX = 0;
+    private const int FEELS_LIKE_INDEX = 0;
 
     public ?float $feels_like {
         get => $this->getData(self::FEELS_LIKE_INDEX);
@@ -41,7 +41,7 @@ final class MainTransfer extends AbstractTransfer
 
     // grnd_level
     public const string GRND_LEVEL = 'grnd_level';
-    protected const int GRND_LEVEL_INDEX = 1;
+    private const int GRND_LEVEL_INDEX = 1;
 
     public ?int $grnd_level {
         get => $this->getData(self::GRND_LEVEL_INDEX);
@@ -50,7 +50,7 @@ final class MainTransfer extends AbstractTransfer
 
     // humidity
     public const string HUMIDITY = 'humidity';
-    protected const int HUMIDITY_INDEX = 2;
+    private const int HUMIDITY_INDEX = 2;
 
     public ?int $humidity {
         get => $this->getData(self::HUMIDITY_INDEX);
@@ -59,7 +59,7 @@ final class MainTransfer extends AbstractTransfer
 
     // pressure
     public const string PRESSURE = 'pressure';
-    protected const int PRESSURE_INDEX = 3;
+    private const int PRESSURE_INDEX = 3;
 
     public ?int $pressure {
         get => $this->getData(self::PRESSURE_INDEX);
@@ -68,7 +68,7 @@ final class MainTransfer extends AbstractTransfer
 
     // sea_level
     public const string SEA_LEVEL = 'sea_level';
-    protected const int SEA_LEVEL_INDEX = 4;
+    private const int SEA_LEVEL_INDEX = 4;
 
     public ?int $sea_level {
         get => $this->getData(self::SEA_LEVEL_INDEX);
@@ -77,7 +77,7 @@ final class MainTransfer extends AbstractTransfer
 
     // temp
     public const string TEMP = 'temp';
-    protected const int TEMP_INDEX = 5;
+    private const int TEMP_INDEX = 5;
 
     public ?float $temp {
         get => $this->getData(self::TEMP_INDEX);
@@ -86,7 +86,7 @@ final class MainTransfer extends AbstractTransfer
 
     // temp_max
     public const string TEMP_MAX = 'temp_max';
-    protected const int TEMP_MAX_INDEX = 6;
+    private const int TEMP_MAX_INDEX = 6;
 
     public ?float $temp_max {
         get => $this->getData(self::TEMP_MAX_INDEX);
@@ -95,7 +95,7 @@ final class MainTransfer extends AbstractTransfer
 
     // temp_min
     public const string TEMP_MIN = 'temp_min';
-    protected const int TEMP_MIN_INDEX = 7;
+    private const int TEMP_MIN_INDEX = 7;
 
     public ?float $temp_min {
         get => $this->getData(self::TEMP_MIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/SysTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/SysTransfer.php
@@ -29,7 +29,7 @@ final class SysTransfer extends AbstractTransfer
 
     // country
     public const string COUNTRY = 'country';
-    protected const int COUNTRY_INDEX = 0;
+    private const int COUNTRY_INDEX = 0;
 
     public ?string $country {
         get => $this->getData(self::COUNTRY_INDEX);
@@ -38,7 +38,7 @@ final class SysTransfer extends AbstractTransfer
 
     // id
     public const string ID = 'id';
-    protected const int ID_INDEX = 1;
+    private const int ID_INDEX = 1;
 
     public ?int $id {
         get => $this->getData(self::ID_INDEX);
@@ -47,7 +47,7 @@ final class SysTransfer extends AbstractTransfer
 
     // sunrise
     public const string SUNRISE = 'sunrise';
-    protected const int SUNRISE_INDEX = 2;
+    private const int SUNRISE_INDEX = 2;
 
     public ?int $sunrise {
         get => $this->getData(self::SUNRISE_INDEX);
@@ -56,7 +56,7 @@ final class SysTransfer extends AbstractTransfer
 
     // sunset
     public const string SUNSET = 'sunset';
-    protected const int SUNSET_INDEX = 3;
+    private const int SUNSET_INDEX = 3;
 
     public ?int $sunset {
         get => $this->getData(self::SUNSET_INDEX);
@@ -65,7 +65,7 @@ final class SysTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 4;
+    private const int TYPE_INDEX = 4;
 
     public ?int $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/WeatherTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/WeatherTransfer.php
@@ -28,7 +28,7 @@ final class WeatherTransfer extends AbstractTransfer
 
     // description
     public const string DESCRIPTION = 'description';
-    protected const int DESCRIPTION_INDEX = 0;
+    private const int DESCRIPTION_INDEX = 0;
 
     public ?string $description {
         get => $this->getData(self::DESCRIPTION_INDEX);
@@ -37,7 +37,7 @@ final class WeatherTransfer extends AbstractTransfer
 
     // icon
     public const string ICON = 'icon';
-    protected const int ICON_INDEX = 1;
+    private const int ICON_INDEX = 1;
 
     public ?string $icon {
         get => $this->getData(self::ICON_INDEX);
@@ -46,7 +46,7 @@ final class WeatherTransfer extends AbstractTransfer
 
     // id
     public const string ID = 'id';
-    protected const int ID_INDEX = 2;
+    private const int ID_INDEX = 2;
 
     public ?int $id {
         get => $this->getData(self::ID_INDEX);
@@ -55,7 +55,7 @@ final class WeatherTransfer extends AbstractTransfer
 
     // main
     public const string MAIN = 'main';
-    protected const int MAIN_INDEX = 3;
+    private const int MAIN_INDEX = 3;
 
     public ?string $main {
         get => $this->getData(self::MAIN_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/OpenWeather/WindTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/OpenWeather/WindTransfer.php
@@ -27,7 +27,7 @@ final class WindTransfer extends AbstractTransfer
 
     // deg
     public const string DEG = 'deg';
-    protected const int DEG_INDEX = 0;
+    private const int DEG_INDEX = 0;
 
     public ?int $deg {
         get => $this->getData(self::DEG_INDEX);
@@ -36,7 +36,7 @@ final class WindTransfer extends AbstractTransfer
 
     // gust
     public const string GUST = 'gust';
-    protected const int GUST_INDEX = 1;
+    private const int GUST_INDEX = 1;
 
     public ?float $gust {
         get => $this->getData(self::GUST_INDEX);
@@ -45,7 +45,7 @@ final class WindTransfer extends AbstractTransfer
 
     // speed
     public const string SPEED = 'speed';
-    protected const int SPEED_INDEX = 2;
+    private const int SPEED_INDEX = 2;
 
     public ?float $speed {
         get => $this->getData(self::SPEED_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/ArdNewsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/ArdNewsTransfer.php
@@ -32,7 +32,7 @@ final class ArdNewsTransfer extends AbstractTransfer
 
     // newStoriesCountLink
     public const string NEW_STORIES_COUNT_LINK = 'newStoriesCountLink';
-    protected const int NEW_STORIES_COUNT_LINK_INDEX = 0;
+    private const int NEW_STORIES_COUNT_LINK_INDEX = 0;
 
     public ?string $newStoriesCountLink {
         get => $this->getData(self::NEW_STORIES_COUNT_LINK_INDEX);
@@ -42,7 +42,7 @@ final class ArdNewsTransfer extends AbstractTransfer
     // news
     #[CollectionPropertyTypeAttribute(NewsTransfer::class)]
     public const string NEWS = 'news';
-    protected const int NEWS_INDEX = 1;
+    private const int NEWS_INDEX = 1;
 
     /** @var \ArrayObject<int,NewsTransfer> */
     public ArrayObject $news {
@@ -52,7 +52,7 @@ final class ArdNewsTransfer extends AbstractTransfer
 
     // nextPage
     public const string NEXT_PAGE = 'nextPage';
-    protected const int NEXT_PAGE_INDEX = 2;
+    private const int NEXT_PAGE_INDEX = 2;
 
     public ?string $nextPage {
         get => $this->getData(self::NEXT_PAGE_INDEX);
@@ -62,7 +62,7 @@ final class ArdNewsTransfer extends AbstractTransfer
     // regional
     #[ArrayPropertyTypeAttribute]
     public const string REGIONAL = 'regional';
-    protected const int REGIONAL_INDEX = 3;
+    private const int REGIONAL_INDEX = 3;
 
     /** @var array<int|string,mixed> */
     public array $regional {
@@ -72,7 +72,7 @@ final class ArdNewsTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 4;
+    private const int TYPE_INDEX = 4;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/BrandingImageTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/BrandingImageTransfer.php
@@ -30,7 +30,7 @@ final class BrandingImageTransfer extends AbstractTransfer
 
     // alttext
     public const string ALTTEXT = 'alttext';
-    protected const int ALTTEXT_INDEX = 0;
+    private const int ALTTEXT_INDEX = 0;
 
     public ?string $alttext {
         get => $this->getData(self::ALTTEXT_INDEX);
@@ -39,7 +39,7 @@ final class BrandingImageTransfer extends AbstractTransfer
 
     // copyright
     public const string COPYRIGHT = 'copyright';
-    protected const int COPYRIGHT_INDEX = 1;
+    private const int COPYRIGHT_INDEX = 1;
 
     public ?string $copyright {
         get => $this->getData(self::COPYRIGHT_INDEX);
@@ -49,7 +49,7 @@ final class BrandingImageTransfer extends AbstractTransfer
     // imageVariants
     #[PropertyTypeAttribute(ImageVariantsTransfer::class)]
     public const string IMAGE_VARIANTS = 'imageVariants';
-    protected const int IMAGE_VARIANTS_INDEX = 2;
+    private const int IMAGE_VARIANTS_INDEX = 2;
 
     public ?ImageVariantsTransfer $imageVariants {
         get => $this->getData(self::IMAGE_VARIANTS_INDEX);
@@ -58,7 +58,7 @@ final class BrandingImageTransfer extends AbstractTransfer
 
     // title
     public const string TITLE = 'title';
-    protected const int TITLE_INDEX = 3;
+    private const int TITLE_INDEX = 3;
 
     public ?string $title {
         get => $this->getData(self::TITLE_INDEX);
@@ -67,7 +67,7 @@ final class BrandingImageTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 4;
+    private const int TYPE_INDEX = 4;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/ImageVariantsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/ImageVariantsTransfer.php
@@ -25,7 +25,7 @@ final class ImageVariantsTransfer extends AbstractTransfer
 
     // original
     public const string ORIGINAL = 'original';
-    protected const int ORIGINAL_INDEX = 0;
+    private const int ORIGINAL_INDEX = 0;
 
     public ?string $original {
         get => $this->getData(self::ORIGINAL_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/NewsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/NewsTransfer.php
@@ -50,7 +50,7 @@ final class NewsTransfer extends AbstractTransfer
     // brandingImage
     #[PropertyTypeAttribute(BrandingImageTransfer::class)]
     public const string BRANDING_IMAGE = 'brandingImage';
-    protected const int BRANDING_IMAGE_INDEX = 0;
+    private const int BRANDING_IMAGE_INDEX = 0;
 
     public ?BrandingImageTransfer $brandingImage {
         get => $this->getData(self::BRANDING_IMAGE_INDEX);
@@ -59,7 +59,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // breakingNews
     public const string BREAKING_NEWS = 'breakingNews';
-    protected const int BREAKING_NEWS_INDEX = 1;
+    private const int BREAKING_NEWS_INDEX = 1;
 
     public ?bool $breakingNews {
         get => $this->getData(self::BREAKING_NEWS_INDEX);
@@ -68,7 +68,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // comments
     public const string COMMENTS = 'comments';
-    protected const int COMMENTS_INDEX = 2;
+    private const int COMMENTS_INDEX = 2;
 
     public ?string $comments {
         get => $this->getData(self::COMMENTS_INDEX);
@@ -77,7 +77,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // date
     public const string DATE = 'date';
-    protected const int DATE_INDEX = 3;
+    private const int DATE_INDEX = 3;
 
     public ?string $date {
         get => $this->getData(self::DATE_INDEX);
@@ -86,7 +86,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // details
     public const string DETAILS = 'details';
-    protected const int DETAILS_INDEX = 4;
+    private const int DETAILS_INDEX = 4;
 
     public ?string $details {
         get => $this->getData(self::DETAILS_INDEX);
@@ -95,7 +95,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // detailsweb
     public const string DETAILSWEB = 'detailsweb';
-    protected const int DETAILSWEB_INDEX = 5;
+    private const int DETAILSWEB_INDEX = 5;
 
     public ?string $detailsweb {
         get => $this->getData(self::DETAILSWEB_INDEX);
@@ -104,7 +104,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // externalId
     public const string EXTERNAL_ID = 'externalId';
-    protected const int EXTERNAL_ID_INDEX = 6;
+    private const int EXTERNAL_ID_INDEX = 6;
 
     public ?string $externalId {
         get => $this->getData(self::EXTERNAL_ID_INDEX);
@@ -113,7 +113,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // firstSentence
     public const string FIRST_SENTENCE = 'firstSentence';
-    protected const int FIRST_SENTENCE_INDEX = 7;
+    private const int FIRST_SENTENCE_INDEX = 7;
 
     public ?string $firstSentence {
         get => $this->getData(self::FIRST_SENTENCE_INDEX);
@@ -123,7 +123,7 @@ final class NewsTransfer extends AbstractTransfer
     // geotags
     #[ArrayPropertyTypeAttribute]
     public const string GEOTAGS = 'geotags';
-    protected const int GEOTAGS_INDEX = 8;
+    private const int GEOTAGS_INDEX = 8;
 
     /** @var array<int|string,mixed> */
     public array $geotags {
@@ -133,7 +133,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // regionId
     public const string REGION_ID = 'regionId';
-    protected const int REGION_ID_INDEX = 9;
+    private const int REGION_ID_INDEX = 9;
 
     public ?int $regionId {
         get => $this->getData(self::REGION_ID_INDEX);
@@ -143,7 +143,7 @@ final class NewsTransfer extends AbstractTransfer
     // regionIds
     #[ArrayPropertyTypeAttribute]
     public const string REGION_IDS = 'regionIds';
-    protected const int REGION_IDS_INDEX = 10;
+    private const int REGION_IDS_INDEX = 10;
 
     /** @var array<int|string,mixed> */
     public array $regionIds {
@@ -153,7 +153,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // ressort
     public const string RESSORT = 'ressort';
-    protected const int RESSORT_INDEX = 11;
+    private const int RESSORT_INDEX = 11;
 
     public ?string $ressort {
         get => $this->getData(self::RESSORT_INDEX);
@@ -162,7 +162,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // shareURL
     public const string SHARE_U_R_L = 'shareURL';
-    protected const int SHARE_U_R_L_INDEX = 12;
+    private const int SHARE_U_R_L_INDEX = 12;
 
     public ?string $shareURL {
         get => $this->getData(self::SHARE_U_R_L_INDEX);
@@ -171,7 +171,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // sophoraId
     public const string SOPHORA_ID = 'sophoraId';
-    protected const int SOPHORA_ID_INDEX = 13;
+    private const int SOPHORA_ID_INDEX = 13;
 
     public ?string $sophoraId {
         get => $this->getData(self::SOPHORA_ID_INDEX);
@@ -181,7 +181,7 @@ final class NewsTransfer extends AbstractTransfer
     // tags
     #[CollectionPropertyTypeAttribute(TagsTransfer::class)]
     public const string TAGS = 'tags';
-    protected const int TAGS_INDEX = 14;
+    private const int TAGS_INDEX = 14;
 
     /** @var \ArrayObject<int,TagsTransfer> */
     public ArrayObject $tags {
@@ -192,7 +192,7 @@ final class NewsTransfer extends AbstractTransfer
     // teaserImage
     #[PropertyTypeAttribute(TeaserImageTransfer::class)]
     public const string TEASER_IMAGE = 'teaserImage';
-    protected const int TEASER_IMAGE_INDEX = 15;
+    private const int TEASER_IMAGE_INDEX = 15;
 
     public ?TeaserImageTransfer $teaserImage {
         get => $this->getData(self::TEASER_IMAGE_INDEX);
@@ -201,7 +201,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // title
     public const string TITLE = 'title';
-    protected const int TITLE_INDEX = 16;
+    private const int TITLE_INDEX = 16;
 
     public ?string $title {
         get => $this->getData(self::TITLE_INDEX);
@@ -210,7 +210,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // topline
     public const string TOPLINE = 'topline';
-    protected const int TOPLINE_INDEX = 17;
+    private const int TOPLINE_INDEX = 17;
 
     public ?string $topline {
         get => $this->getData(self::TOPLINE_INDEX);
@@ -220,7 +220,7 @@ final class NewsTransfer extends AbstractTransfer
     // tracking
     #[CollectionPropertyTypeAttribute(TrackingTransfer::class)]
     public const string TRACKING = 'tracking';
-    protected const int TRACKING_INDEX = 18;
+    private const int TRACKING_INDEX = 18;
 
     /** @var \ArrayObject<int,TrackingTransfer> */
     public ArrayObject $tracking {
@@ -230,7 +230,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 19;
+    private const int TYPE_INDEX = 19;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);
@@ -239,7 +239,7 @@ final class NewsTransfer extends AbstractTransfer
 
     // updateCheckUrl
     public const string UPDATE_CHECK_URL = 'updateCheckUrl';
-    protected const int UPDATE_CHECK_URL_INDEX = 20;
+    private const int UPDATE_CHECK_URL_INDEX = 20;
 
     public ?string $updateCheckUrl {
         get => $this->getData(self::UPDATE_CHECK_URL_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TagsTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TagsTransfer.php
@@ -25,7 +25,7 @@ final class TagsTransfer extends AbstractTransfer
 
     // tag
     public const string TAG = 'tag';
-    protected const int TAG_INDEX = 0;
+    private const int TAG_INDEX = 0;
 
     public ?string $tag {
         get => $this->getData(self::TAG_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TeaserImageTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TeaserImageTransfer.php
@@ -30,7 +30,7 @@ final class TeaserImageTransfer extends AbstractTransfer
 
     // alttext
     public const string ALTTEXT = 'alttext';
-    protected const int ALTTEXT_INDEX = 0;
+    private const int ALTTEXT_INDEX = 0;
 
     public ?string $alttext {
         get => $this->getData(self::ALTTEXT_INDEX);
@@ -39,7 +39,7 @@ final class TeaserImageTransfer extends AbstractTransfer
 
     // copyright
     public const string COPYRIGHT = 'copyright';
-    protected const int COPYRIGHT_INDEX = 1;
+    private const int COPYRIGHT_INDEX = 1;
 
     public ?string $copyright {
         get => $this->getData(self::COPYRIGHT_INDEX);
@@ -49,7 +49,7 @@ final class TeaserImageTransfer extends AbstractTransfer
     // imageVariants
     #[ArrayPropertyTypeAttribute]
     public const string IMAGE_VARIANTS = 'imageVariants';
-    protected const int IMAGE_VARIANTS_INDEX = 2;
+    private const int IMAGE_VARIANTS_INDEX = 2;
 
     /** @var array<int|string,mixed> */
     public array $imageVariants {
@@ -59,7 +59,7 @@ final class TeaserImageTransfer extends AbstractTransfer
 
     // title
     public const string TITLE = 'title';
-    protected const int TITLE_INDEX = 3;
+    private const int TITLE_INDEX = 3;
 
     public ?string $title {
         get => $this->getData(self::TITLE_INDEX);
@@ -68,7 +68,7 @@ final class TeaserImageTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 4;
+    private const int TYPE_INDEX = 4;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/DefinitionGenerator/Generated/Tagesschau/TrackingTransfer.php
+++ b/tests/integration/DefinitionGenerator/Generated/Tagesschau/TrackingTransfer.php
@@ -34,7 +34,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // av_full_show
     public const string AV_FULL_SHOW = 'av_full_show';
-    protected const int AV_FULL_SHOW_INDEX = 0;
+    private const int AV_FULL_SHOW_INDEX = 0;
 
     public ?bool $av_full_show {
         get => $this->getData(self::AV_FULL_SHOW_INDEX);
@@ -43,7 +43,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // bcr
     public const string BCR = 'bcr';
-    protected const int BCR_INDEX = 1;
+    private const int BCR_INDEX = 1;
 
     public ?string $bcr {
         get => $this->getData(self::BCR_INDEX);
@@ -52,7 +52,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // cid
     public const string CID = 'cid';
-    protected const int CID_INDEX = 2;
+    private const int CID_INDEX = 2;
 
     public ?string $cid {
         get => $this->getData(self::CID_INDEX);
@@ -61,7 +61,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // ctp
     public const string CTP = 'ctp';
-    protected const int CTP_INDEX = 3;
+    private const int CTP_INDEX = 3;
 
     public ?string $ctp {
         get => $this->getData(self::CTP_INDEX);
@@ -70,7 +70,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // otp
     public const string OTP = 'otp';
-    protected const int OTP_INDEX = 4;
+    private const int OTP_INDEX = 4;
 
     public ?string $otp {
         get => $this->getData(self::OTP_INDEX);
@@ -79,7 +79,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // pdt
     public const string PDT = 'pdt';
-    protected const int PDT_INDEX = 5;
+    private const int PDT_INDEX = 5;
 
     public ?string $pdt {
         get => $this->getData(self::PDT_INDEX);
@@ -88,7 +88,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // pti
     public const string PTI = 'pti';
-    protected const int PTI_INDEX = 6;
+    private const int PTI_INDEX = 6;
 
     public ?string $pti {
         get => $this->getData(self::PTI_INDEX);
@@ -97,7 +97,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // sid
     public const string SID = 'sid';
-    protected const int SID_INDEX = 7;
+    private const int SID_INDEX = 7;
 
     public ?string $sid {
         get => $this->getData(self::SID_INDEX);
@@ -106,7 +106,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // src
     public const string SRC = 'src';
-    protected const int SRC_INDEX = 8;
+    private const int SRC_INDEX = 8;
 
     public ?string $src {
         get => $this->getData(self::SRC_INDEX);
@@ -115,7 +115,7 @@ final class TrackingTransfer extends AbstractTransfer
 
     // type
     public const string TYPE = 'type';
-    protected const int TYPE_INDEX = 9;
+    private const int TYPE_INDEX = 9;
 
     public ?string $type {
         get => $this->getData(self::TYPE_INDEX);

--- a/tests/integration/Transfer/Generated/AuthorTransfer.php
+++ b/tests/integration/Transfer/Generated/AuthorTransfer.php
@@ -26,7 +26,7 @@ final class AuthorTransfer extends AbstractTransfer
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const int FIRST_NAME_INDEX = 0;
+    private const int FIRST_NAME_INDEX = 0;
 
     public string $firstName {
         get => $this->getData(self::FIRST_NAME_INDEX);
@@ -35,7 +35,7 @@ final class AuthorTransfer extends AbstractTransfer
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const int LAST_NAME_INDEX = 1;
+    private const int LAST_NAME_INDEX = 1;
 
     public string $lastName {
         get => $this->getData(self::LAST_NAME_INDEX);

--- a/tests/integration/Transfer/Generated/BcMath/BcMathNumberTransfer.php
+++ b/tests/integration/Transfer/Generated/BcMath/BcMathNumberTransfer.php
@@ -28,7 +28,7 @@ final class BcMathNumberTransfer extends AbstractTransfer
     // iAmNumber
     #[NumberPropertyTypeAttribute(Number::class)]
     public const string I_AM_NUMBER = 'iAmNumber';
-    protected const int I_AM_NUMBER_INDEX = 0;
+    private const int I_AM_NUMBER_INDEX = 0;
 
     public ?Number $iAmNumber {
         get => $this->getData(self::I_AM_NUMBER_INDEX);

--- a/tests/integration/Transfer/Generated/BookTransfer.php
+++ b/tests/integration/Transfer/Generated/BookTransfer.php
@@ -33,7 +33,7 @@ final class BookTransfer extends AbstractTransfer
     // bookmarks
     #[CollectionPropertyTypeAttribute(BookmarkData::class)]
     public const string BOOKMARKS = 'bookmarks';
-    protected const int BOOKMARKS_INDEX = 0;
+    private const int BOOKMARKS_INDEX = 0;
 
     /** @var \ArrayObject<int,TransferInterface&BookmarkData> */
     public ArrayObject $bookmarks {
@@ -44,7 +44,7 @@ final class BookTransfer extends AbstractTransfer
     // data
     #[PropertyTypeAttribute(BookData::class)]
     public const string DATA = 'data';
-    protected const int DATA_INDEX = 1;
+    private const int DATA_INDEX = 1;
 
     public TransferInterface&BookData $data {
         get => $this->getData(self::DATA_INDEX);

--- a/tests/integration/Transfer/Generated/ItemCollectionTransfer.php
+++ b/tests/integration/Transfer/Generated/ItemCollectionTransfer.php
@@ -30,7 +30,7 @@ final class ItemCollectionTransfer extends AbstractTransfer
     // item
     #[PropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEM = 'item';
-    protected const int ITEM_INDEX = 0;
+    private const int ITEM_INDEX = 0;
 
     public ?ItemTransfer $item {
         get => $this->getData(self::ITEM_INDEX);
@@ -40,7 +40,7 @@ final class ItemCollectionTransfer extends AbstractTransfer
     // items
     #[CollectionPropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEMS = 'items';
-    protected const int ITEMS_INDEX = 1;
+    private const int ITEMS_INDEX = 1;
 
     /** @var \ArrayObject<int,ItemTransfer> */
     public ArrayObject $items {

--- a/tests/integration/Transfer/Generated/ItemTransfer.php
+++ b/tests/integration/Transfer/Generated/ItemTransfer.php
@@ -44,7 +44,7 @@ final class ItemTransfer extends AbstractTransfer
     // iAmArray
     #[ArrayPropertyTypeAttribute]
     public const string I_AM_ARRAY = 'iAmArray';
-    protected const int I_AM_ARRAY_INDEX = 0;
+    private const int I_AM_ARRAY_INDEX = 0;
 
     /** @var array<int|string,mixed> */
     public array $iAmArray {
@@ -55,7 +55,7 @@ final class ItemTransfer extends AbstractTransfer
     // iAmArrayObject
     #[ArrayObjectPropertyTypeAttribute]
     public const string I_AM_ARRAY_OBJECT = 'iAmArrayObject';
-    protected const int I_AM_ARRAY_OBJECT_INDEX = 1;
+    private const int I_AM_ARRAY_OBJECT_INDEX = 1;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $iAmArrayObject {
@@ -65,7 +65,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmBool
     public const string I_AM_BOOL = 'iAmBool';
-    protected const int I_AM_BOOL_INDEX = 2;
+    private const int I_AM_BOOL_INDEX = 2;
 
     public ?bool $iAmBool {
         get => $this->getData(self::I_AM_BOOL_INDEX);
@@ -75,7 +75,7 @@ final class ItemTransfer extends AbstractTransfer
     // iAmDateTime
     #[DateTimePropertyTypeAttribute(DateTime::class)]
     public const string I_AM_DATE_TIME = 'iAmDateTime';
-    protected const int I_AM_DATE_TIME_INDEX = 3;
+    private const int I_AM_DATE_TIME_INDEX = 3;
 
     public ?DateTime $iAmDateTime {
         get => $this->getData(self::I_AM_DATE_TIME_INDEX);
@@ -85,7 +85,7 @@ final class ItemTransfer extends AbstractTransfer
     // iAmDateTimeImmutable
     #[DateTimePropertyTypeAttribute(DateTimeImmutable::class)]
     public const string I_AM_DATE_TIME_IMMUTABLE = 'iAmDateTimeImmutable';
-    protected const int I_AM_DATE_TIME_IMMUTABLE_INDEX = 4;
+    private const int I_AM_DATE_TIME_IMMUTABLE_INDEX = 4;
 
     public ?DateTimeImmutable $iAmDateTimeImmutable {
         get => $this->getData(self::I_AM_DATE_TIME_IMMUTABLE_INDEX);
@@ -95,7 +95,7 @@ final class ItemTransfer extends AbstractTransfer
     // iAmEnum
     #[EnumPropertyTypeAttribute(ImBackedEnum::class)]
     public const string I_AM_ENUM = 'iAmEnum';
-    protected const int I_AM_ENUM_INDEX = 5;
+    private const int I_AM_ENUM_INDEX = 5;
 
     public ?ImBackedEnum $iAmEnum {
         get => $this->getData(self::I_AM_ENUM_INDEX);
@@ -104,7 +104,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmFalse
     public const string I_AM_FALSE = 'iAmFalse';
-    protected const int I_AM_FALSE_INDEX = 6;
+    private const int I_AM_FALSE_INDEX = 6;
 
     public ?false $iAmFalse {
         get => $this->getData(self::I_AM_FALSE_INDEX);
@@ -113,7 +113,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmFloat
     public const string I_AM_FLOAT = 'iAmFloat';
-    protected const int I_AM_FLOAT_INDEX = 7;
+    private const int I_AM_FLOAT_INDEX = 7;
 
     public ?float $iAmFloat {
         get => $this->getData(self::I_AM_FLOAT_INDEX);
@@ -122,7 +122,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmInt
     public const string I_AM_INT = 'iAmInt';
-    protected const int I_AM_INT_INDEX = 8;
+    private const int I_AM_INT_INDEX = 8;
 
     public ?int $iAmInt {
         get => $this->getData(self::I_AM_INT_INDEX);
@@ -131,7 +131,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmString
     public const string I_AM_STRING = 'iAmString';
-    protected const int I_AM_STRING_INDEX = 9;
+    private const int I_AM_STRING_INDEX = 9;
 
     public ?string $iAmString {
         get => $this->getData(self::I_AM_STRING_INDEX);
@@ -140,7 +140,7 @@ final class ItemTransfer extends AbstractTransfer
 
     // iAmTrue
     public const string I_AM_TRUE = 'iAmTrue';
-    protected const int I_AM_TRUE_INDEX = 10;
+    private const int I_AM_TRUE_INDEX = 10;
 
     public ?true $iAmTrue {
         get => $this->getData(self::I_AM_TRUE_INDEX);

--- a/tests/integration/Transfer/Generated/NamespaceTransfer.php
+++ b/tests/integration/Transfer/Generated/NamespaceTransfer.php
@@ -33,7 +33,7 @@ final class NamespaceTransfer extends AbstractTransfer
     // items
     #[CollectionPropertyTypeAttribute(ItemTransfer::class)]
     public const string ITEMS = 'items';
-    protected const int ITEMS_INDEX = 0;
+    private const int ITEMS_INDEX = 0;
 
     /** @var \ArrayObject<int,TransferInterface&ItemTransfer> */
     public ArrayObject $items {
@@ -44,7 +44,7 @@ final class NamespaceTransfer extends AbstractTransfer
     // required
     #[PropertyTypeAttribute(RequiredAlias::class)]
     public const string REQUIRED = 'required';
-    protected const int REQUIRED_INDEX = 1;
+    private const int REQUIRED_INDEX = 1;
 
     public TransferInterface&RequiredAlias $required {
         get => $this->getData(self::REQUIRED_INDEX);

--- a/tests/integration/Transfer/Generated/ProtectedTransfer.php
+++ b/tests/integration/Transfer/Generated/ProtectedTransfer.php
@@ -25,7 +25,7 @@ final class ProtectedTransfer extends AbstractTransfer
 
     // iAmProtected
     public const string I_AM_PROTECTED = 'iAmProtected';
-    protected const int I_AM_PROTECTED_INDEX = 0;
+    private const int I_AM_PROTECTED_INDEX = 0;
 
     public protected(set) ?string $iAmProtected {
         get => $this->getData(self::I_AM_PROTECTED_INDEX);

--- a/tests/integration/Transfer/Generated/RequiredTransfer.php
+++ b/tests/integration/Transfer/Generated/RequiredTransfer.php
@@ -25,7 +25,7 @@ final class RequiredTransfer extends AbstractTransfer
 
     // iAmRequired
     public const string I_AM_REQUIRED = 'iAmRequired';
-    protected const int I_AM_REQUIRED_INDEX = 0;
+    private const int I_AM_REQUIRED_INDEX = 0;
 
     public string $iAmRequired {
         get => $this->getData(self::I_AM_REQUIRED_INDEX);

--- a/tests/integration/TransferGenerator/Generated/Success/AddressBookTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressBookTransfer.php
@@ -37,7 +37,7 @@ final class AddressBookTransfer extends AbstractTransfer
     // addresses
     #[CollectionPropertyTypeAttribute(AddressTransfer::class)]
     public const string ADDRESSES = 'addresses';
-    protected const int ADDRESSES_INDEX = 0;
+    private const int ADDRESSES_INDEX = 0;
 
     /** @var \ArrayObject<int,AddressTransfer> */
     public ArrayObject $addresses {
@@ -48,7 +48,7 @@ final class AddressBookTransfer extends AbstractTransfer
     // categories
     #[ArrayPropertyTypeAttribute]
     public const string CATEGORIES = 'categories';
-    protected const int CATEGORIES_INDEX = 1;
+    private const int CATEGORIES_INDEX = 1;
 
     /** @var array<int|string,mixed> */
     public array $categories {
@@ -59,7 +59,7 @@ final class AddressBookTransfer extends AbstractTransfer
     // label
     #[EnumPropertyTypeAttribute(AddressLabelEnum::class)]
     public const string LABEL = 'label';
-    protected const int LABEL_INDEX = 2;
+    private const int LABEL_INDEX = 2;
 
     public ?AddressLabelEnum $label {
         get => $this->getData(self::LABEL_INDEX);
@@ -69,7 +69,7 @@ final class AddressBookTransfer extends AbstractTransfer
     // labelAlias
     #[EnumPropertyTypeAttribute(AliasAddressLabelEnum::class)]
     public const string LABEL_ALIAS = 'labelAlias';
-    protected const int LABEL_ALIAS_INDEX = 3;
+    private const int LABEL_ALIAS_INDEX = 3;
 
     public ?AliasAddressLabelEnum $labelAlias {
         get => $this->getData(self::LABEL_ALIAS_INDEX);
@@ -78,7 +78,7 @@ final class AddressBookTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 4;
+    private const int NAME_INDEX = 4;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);
@@ -87,7 +87,7 @@ final class AddressBookTransfer extends AbstractTransfer
 
     // uuid
     public const string UUID = 'uuid';
-    protected const int UUID_INDEX = 5;
+    private const int UUID_INDEX = 5;
 
     public ?string $uuid {
         get => $this->getData(self::UUID_INDEX);

--- a/tests/integration/TransferGenerator/Generated/Success/AddressStatisticsTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressStatisticsTransfer.php
@@ -33,7 +33,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // addressBookUuid
     public const string ADDRESS_BOOK_UUID = 'addressBookUuid';
-    protected const int ADDRESS_BOOK_UUID_INDEX = 0;
+    private const int ADDRESS_BOOK_UUID_INDEX = 0;
 
     public ?string $addressBookUuid {
         get => $this->getData(self::ADDRESS_BOOK_UUID_INDEX);
@@ -42,7 +42,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // addressUuid
     public const string ADDRESS_UUID = 'addressUuid';
-    protected const int ADDRESS_UUID_INDEX = 1;
+    private const int ADDRESS_UUID_INDEX = 1;
 
     public ?string $addressUuid {
         get => $this->getData(self::ADDRESS_UUID_INDEX);
@@ -51,7 +51,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const int IS_ACTIVE_INDEX = 2;
+    private const int IS_ACTIVE_INDEX = 2;
 
     public ?true $isActive {
         get => $this->getData(self::IS_ACTIVE_INDEX);
@@ -60,7 +60,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // isBlocked
     public const string IS_BLOCKED = 'isBlocked';
-    protected const int IS_BLOCKED_INDEX = 3;
+    private const int IS_BLOCKED_INDEX = 3;
 
     public ?false $isBlocked {
         get => $this->getData(self::IS_BLOCKED_INDEX);
@@ -69,7 +69,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // orderAverage
     public const string ORDER_AVERAGE = 'orderAverage';
-    protected const int ORDER_AVERAGE_INDEX = 4;
+    private const int ORDER_AVERAGE_INDEX = 4;
 
     public ?float $orderAverage {
         get => $this->getData(self::ORDER_AVERAGE_INDEX);
@@ -78,7 +78,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
 
     // orderCount
     public const string ORDER_COUNT = 'orderCount';
-    protected const int ORDER_COUNT_INDEX = 5;
+    private const int ORDER_COUNT_INDEX = 5;
 
     public ?int $orderCount {
         get => $this->getData(self::ORDER_COUNT_INDEX);
@@ -88,7 +88,7 @@ final class AddressStatisticsTransfer extends AbstractTransfer
     // orderReferences
     #[ArrayObjectPropertyTypeAttribute]
     public const string ORDER_REFERENCES = 'orderReferences';
-    protected const int ORDER_REFERENCES_INDEX = 6;
+    private const int ORDER_REFERENCES_INDEX = 6;
 
     /** @var \ArrayObject<string|int,mixed> */
     public ArrayObject $orderReferences {

--- a/tests/integration/TransferGenerator/Generated/Success/AddressTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/AddressTransfer.php
@@ -36,7 +36,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // address1
     public const string ADDRESS1 = 'address1';
-    protected const int ADDRESS1_INDEX = 0;
+    private const int ADDRESS1_INDEX = 0;
 
     public ?string $address1 {
         get => $this->getData(self::ADDRESS1_INDEX);
@@ -45,7 +45,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // address2
     public const string ADDRESS2 = 'address2';
-    protected const int ADDRESS2_INDEX = 1;
+    private const int ADDRESS2_INDEX = 1;
 
     public ?string $address2 {
         get => $this->getData(self::ADDRESS2_INDEX);
@@ -54,7 +54,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // address3
     public const string ADDRESS3 = 'address3';
-    protected const int ADDRESS3_INDEX = 2;
+    private const int ADDRESS3_INDEX = 2;
 
     public ?string $address3 {
         get => $this->getData(self::ADDRESS3_INDEX);
@@ -64,7 +64,7 @@ final class AddressTransfer extends AbstractTransfer
     // country
     #[CollectionPropertyTypeAttribute(CountryTransfer::class)]
     public const string COUNTRY = 'country';
-    protected const int COUNTRY_INDEX = 3;
+    private const int COUNTRY_INDEX = 3;
 
     /** @var \ArrayObject<int,CountryTransfer> */
     public ArrayObject $country {
@@ -74,7 +74,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // firstName
     public const string FIRST_NAME = 'firstName';
-    protected const int FIRST_NAME_INDEX = 4;
+    private const int FIRST_NAME_INDEX = 4;
 
     public ?string $firstName {
         get => $this->getData(self::FIRST_NAME_INDEX);
@@ -83,7 +83,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // isActive
     public const string IS_ACTIVE = 'isActive';
-    protected const int IS_ACTIVE_INDEX = 5;
+    private const int IS_ACTIVE_INDEX = 5;
 
     public ?bool $isActive {
         get => $this->getData(self::IS_ACTIVE_INDEX);
@@ -92,7 +92,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // lastName
     public const string LAST_NAME = 'lastName';
-    protected const int LAST_NAME_INDEX = 6;
+    private const int LAST_NAME_INDEX = 6;
 
     public ?string $lastName {
         get => $this->getData(self::LAST_NAME_INDEX);
@@ -101,7 +101,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // phone
     public const string PHONE = 'phone';
-    protected const int PHONE_INDEX = 7;
+    private const int PHONE_INDEX = 7;
 
     public ?string $phone {
         get => $this->getData(self::PHONE_INDEX);
@@ -110,7 +110,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // uuid
     public const string UUID = 'uuid';
-    protected const int UUID_INDEX = 8;
+    private const int UUID_INDEX = 8;
 
     public ?string $uuid {
         get => $this->getData(self::UUID_INDEX);
@@ -119,7 +119,7 @@ final class AddressTransfer extends AbstractTransfer
 
     // zipCode
     public const string ZIP_CODE = 'zipCode';
-    protected const int ZIP_CODE_INDEX = 9;
+    private const int ZIP_CODE_INDEX = 9;
 
     public ?string $zipCode {
         get => $this->getData(self::ZIP_CODE_INDEX);

--- a/tests/integration/TransferGenerator/Generated/Success/CountryTransfer.php
+++ b/tests/integration/TransferGenerator/Generated/Success/CountryTransfer.php
@@ -26,7 +26,7 @@ final class CountryTransfer extends AbstractTransfer
 
     // iso2Code
     public const string ISO2_CODE = 'iso2Code';
-    protected const int ISO2_CODE_INDEX = 0;
+    private const int ISO2_CODE_INDEX = 0;
 
     public ?string $iso2Code {
         get => $this->getData(self::ISO2_CODE_INDEX);
@@ -35,7 +35,7 @@ final class CountryTransfer extends AbstractTransfer
 
     // name
     public const string NAME = 'name';
-    protected const int NAME_INDEX = 1;
+    private const int NAME_INDEX = 1;
 
     public ?string $name {
         get => $this->getData(self::NAME_INDEX);

--- a/tests/unit/DefinitionGenerator/Generator/Render/DefinitionRenderTest.php
+++ b/tests/unit/DefinitionGenerator/Generator/Render/DefinitionRenderTest.php
@@ -126,6 +126,7 @@ DEFINITION,
 
         $contentTransfer->properties[] = $propertyTransfer;
 
+        // Expect
         $this->expectException(DefinitionGeneratorException::class);
 
         // Act


### PR DESCRIPTION
Release 3.0.6
=========

Description
-----------

### Imporvements

**Transfer Object:**

1. Changed transfer object template to set private visability instead of protected on the `*_INDEX` constants

**Transfer Object Generator:**

1. Optimized transfer object `ConfigFilterTrait`
2. Removed string type casting on `ProtectedPropertyExpander`

**Action, optional:**

1. Regenerate Transfer Objects to apply constant visibility changes

Type of Change
--------------

- [x] Bug fix (non-breaking change which fixes an issue)

Checklist
---------

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [x] I agree to follow this project's [Code of Conduct](https://github.com/picamator/transfer-object/blob/main/CODE_OF_CONDUCT.md).
